### PR TITLE
feat(eval): automated transcription/diarization evaluation harness (AMI corpus)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ logs/
 # Coverage
 .coverage
 htmlcov/
+
+# Evaluation harness cache (downloaded AMI audio/references — large, not source)
+.eval_cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,9 @@ The main entry point is `run.sh` which handles all operations:
 - **Process Recordings**: `./run.sh process`
 - **Check Queue Status**: `./run.sh status`
 - **Discard a Recording**: `./run.sh discard`
+- **Start Web UI**: `./run.sh web` (serves the browser UI at http://localhost:5000; runs `python -m web.app`)
+
+The web UI is the recommended interface for day-to-day use. It wraps the same recording/processing logic as the CLI, adds one-click controls, and surfaces the day's calendar meetings. Configure it via these `.env` variables: `WEB_HOST` (default `127.0.0.1`), `WEB_PORT` (default `5000`), and `FLASK_DEBUG` (default `False`). Calendar filtering uses `CALENDAR_INCLUDE` / `CALENDAR_EXCLUDE` (comma-separated calendar-name substrings) and `USER_EMAIL` to identify yourself among attendees.
 
 ## Code Architecture
 
@@ -75,15 +78,22 @@ The codebase consists of:
    - `scripts/transcribe.py` - Transcribes audio using MLX Whisper (Apple Silicon optimized)
    - `scripts/interleave.py` - Merges separate transcripts into a single chronological file
    - `scripts/filter_hallucinations.py` - Removes common hallucinations from Whisper transcriptions
+   - Shared support modules used by both the CLI and web app: `scripts/config.py` (loads `.env` config), `scripts/queue_manager.py` (atomic reads/writes of `processing_queue.csv`), `scripts/root_detection.py` (locates the project root and sets up imports), `scripts/log_sanitizer.py` (redacts sensitive data from logs), and `scripts/dependencies.py` (startup dependency checks)
 
-3. **Data Flow**:
+3. **Web App** (`web/`): A Flask server that provides a browser UI over the same recording/processing logic as the CLI.
+   - `web/app.py` - Flask server and JSON API. Routes: `/` (UI), `/api/status`, `/api/meetings`, `/api/start`, `/api/stop`, `/api/abort`, `/api/process`, `/api/processing-status`, `/api/discard`. Launched via `run.sh web` (`python -m web.app`).
+   - `web/recorder.py` - `RecordingController`: orchestrates start/stop/abort recording (shelling out to `obs_controller.py`, auto-launching OBS if needed), manages the `.pending_meeting` file and the queue via `QueueManager`, and runs `run.sh process` in a background thread with output logged to `logs/processing.log`.
+   - `web/calendar_service.py` - `CalendarService`: reads the day's meetings from macOS Calendar.app via EventKit (PyObjC). Filters out all-day events, solo events, and stale past meetings; extracts Zoom links and accepted/tentative attendee names. macOS-only (degrades to an empty list elsewhere).
+   - `web/templates/index.html`, `web/static/` - Frontend UI (HTML, `app.js`, `style.css`).
+
+4. **Data Flow**:
    - Recording creation: OBS creates a MKV file with multiple audio tracks
    - Audio extraction: FFmpeg extracts "Me" and "Others" audio tracks as separate WAV files
    - Transcription: Whisper converts WAV files to SRT transcripts
    - Post-processing: Hallucination filtering cleans transcripts
    - Final output: Interleaving script combines transcripts into a chronological TXT file
 
-4. **File Organization**:
+5. **File Organization**:
    - `processing_queue.csv` - Tracks recording status (recorded, processed, discarded)
    - `recordings/` (or configured path) - Contains final transcript files:
      - `YYYYMMDD-Meeting-Name_transcript.txt`

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -32,8 +32,12 @@ Audio and the diarization RTTM references are downloaded on demand into
 ```bash
 source venv/bin/activate
 pip install -r requirements.txt          # adds jiwer; pyannote.metrics ships with pyannote.audio
-pip install datasets                      # OPTIONAL — only needed for WER reference text
 ```
+
+The WER reference transcript is fetched over plain HTTP from the HF
+datasets-server (no `datasets` package needed). On the very first fetch the
+server spends ~30–60 s building a filter index (the harness retries through
+the transient "index is loading" responses), then caches the result.
 
 Diarization (DER) needs a HuggingFace token with the pyannote model licenses
 accepted — same setup as `scripts/diarize.py` (`HF_TOKEN` in `.env`).
@@ -58,9 +62,21 @@ python -m evaluation.run_eval --asr-model large-v3 --no-diarize
 python -m evaluation.run_eval IS1009a ES2004a --collar 0.25
 ```
 
-Output is a Markdown table (WER, DER + miss/false-alarm/confusion, timings).
-Use `--collar 0.0` (default) for numbers comparable to pyannote's published
-benchmarks; `--collar 0.25` for the older lenient scoring.
+Output is a Markdown table with two DER columns plus timings:
+
+- **DER (raw)** — pyannote's *native* diarization output, UEM-bounded. This is
+  the apples-to-apples number for comparing diarization *models* (#3), closest
+  to pyannote's published figures. Miss / FA / Conf are reported for this.
+- **DER (srt)** — speaker labels applied to Whisper segments by max-overlap, i.e.
+  what the pipeline *actually* emits in the transcript. The gap between the two
+  is the cost of segment-span labeling and is what #6 (word-level assignment)
+  targets.
+
+Both come from a single pyannote run. Use `--collar 0.0` (default) for numbers
+comparable to pyannote's published benchmarks; `--collar 0.25` for the older
+lenient scoring. The diarization model is defined once in
+`scripts/diarize.py::DIARIZATION_MODEL`, so #3's model bump updates the pipeline
+and the harness together.
 
 ### Comparing changes (#3–#6)
 
@@ -86,12 +102,12 @@ RUN_EVAL=1 RUN_EVAL_FULL=1 python -m pytest tests/test_eval_harness.py -m eval -
 
 ## Status / known limitations
 
-- **DER path** is wired end-to-end and verified against real AMI ground truth.
-- **WER reference** auto-fetch is best-effort via the optional `datasets` package;
-  if unavailable the harness reports WER as `—` and still produces DER. You can
-  always pass your own reference transcript by writing one to
-  `.eval_cache/ami/transcripts/<MEETING>.txt`.
+- **DER** (raw + srt) is wired end-to-end and verified against real AMI ground
+  truth, UEM-bounded when the UEM is available.
+- **WER reference** is fetched from the HF datasets-server filter API over
+  `edinburghcstr/ami` (pure HTTP). If the service is unavailable the harness
+  reports WER as `—` and still produces DER. You can also drop your own
+  reference at `.eval_cache/ami/transcripts/<MEETING>.txt`.
 - RTFx/throughput numbers are wall-clock on *this* machine — use for relative
   comparison, not as absolute leaderboard figures.
-- Baseline numbers for today's stack are **not yet recorded** — run the baseline
-  command above (needs a HF token for the DER half) and paste the table into #2.
+- Baseline numbers for today's stack are recorded in issue #2.

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -1,0 +1,97 @@
+# Evaluation harness
+
+Automated, reproducible measurement of the pipeline's **transcription accuracy
+(WER)** and **speaker diarization accuracy (DER)** against ground-truth meeting
+audio, so model/technique changes (issues #3–#6) can be compared apples-to-apples
+instead of eyeballed. Tracks GitHub issue **#2**.
+
+## Why the AMI Meeting Corpus
+
+[AMI](https://groups.inf.ed.ac.uk/ami/corpus/) is the standard public
+(CC-BY-4.0) multi-participant meeting dataset, and it maps onto our architecture:
+
+- ~100 h of 4-person English meetings.
+- A continuous **mixed-headset** track we feed as the "Others" track.
+- Ground truth for **both** metrics: manual transcripts (→ WER) and speaker
+  segmentation (→ DER) — the same references behind published community-1 / 3.1
+  DER numbers, so our DER is comparable.
+
+Audio and the diarization RTTM references are downloaded on demand into
+`.eval_cache/` (gitignored — never committed).
+
+## Components
+
+| File | Role |
+|---|---|
+| `scoring.py` | Pure WER (jiwer) + DER (pyannote.metrics) + SRT/RTTM converters. Fully unit-tested. |
+| `datasets_ami.py` | Fetch a fixed small AMI subset (audio from the Edinburgh mirror, RTTM from pyannote's `AMI-diarization-setup`). |
+| `run_eval.py` | Orchestrator/CLI: drives the *real* pipeline (`scripts/transcribe.py`, `scripts/diarize.py`) then scores. |
+
+## Setup
+
+```bash
+source venv/bin/activate
+pip install -r requirements.txt          # adds jiwer; pyannote.metrics ships with pyannote.audio
+pip install datasets                      # OPTIONAL — only needed for WER reference text
+```
+
+Diarization (DER) needs a HuggingFace token with the pyannote model licenses
+accepted — same setup as `scripts/diarize.py` (`HF_TOKEN` in `.env`).
+
+If you hit `CERTIFICATE_VERIFY_FAILED` (common on macOS / behind a corporate
+proxy), the downloader uses `certifi` automatically; as a last resort set
+`EVAL_IGNORE_SSL=true`.
+
+## Running
+
+```bash
+# Pre-fetch the default subset (optional; run_eval fetches on demand)
+python -m evaluation.datasets_ami
+
+# Baseline: current stack (whisper turbo + pyannote 3.1) on the default subset
+python -m evaluation.run_eval --json baseline.json
+
+# WER only (no HF token needed), different model
+python -m evaluation.run_eval --asr-model large-v3 --no-diarize
+
+# Specific meetings, lenient NIST-style collar
+python -m evaluation.run_eval IS1009a ES2004a --collar 0.25
+```
+
+Output is a Markdown table (WER, DER + miss/false-alarm/confusion, timings).
+Use `--collar 0.0` (default) for numbers comparable to pyannote's published
+benchmarks; `--collar 0.25` for the older lenient scoring.
+
+### Comparing changes (#3–#6)
+
+- **#3 diarization model**: after pointing `scripts/diarize.py` at
+  `community-1`, re-run and pass `--diar-model-label pyannote/speaker-diarization-community-1`.
+- **#4 Parakeet ASR**: implement the `parakeet` branch in `run_eval._transcribe`,
+  then `--asr-backend parakeet`.
+- **#5 VAD / #6 word-level assignment**: changes land in the pipeline; just re-run
+  and compare WER / DER to the recorded baseline.
+
+## Tests
+
+```bash
+# Fast, hermetic scoring unit tests (run with the default suite)
+python -m pytest tests/test_eval_scoring.py
+
+# Opt-in E2E (downloads AMI data; needs network)
+RUN_EVAL=1 python -m pytest tests/test_eval_harness.py -m eval -s
+
+# Full E2E incl. transcription + diarization (slow; needs models + HF_TOKEN)
+RUN_EVAL=1 RUN_EVAL_FULL=1 python -m pytest tests/test_eval_harness.py -m eval -s
+```
+
+## Status / known limitations
+
+- **DER path** is wired end-to-end and verified against real AMI ground truth.
+- **WER reference** auto-fetch is best-effort via the optional `datasets` package;
+  if unavailable the harness reports WER as `—` and still produces DER. You can
+  always pass your own reference transcript by writing one to
+  `.eval_cache/ami/transcripts/<MEETING>.txt`.
+- RTFx/throughput numbers are wall-clock on *this* machine — use for relative
+  comparison, not as absolute leaderboard figures.
+- Baseline numbers for today's stack are **not yet recorded** — run the baseline
+  command above (needs a HF token for the DER half) and paste the table into #2.

--- a/evaluation/__init__.py
+++ b/evaluation/__init__.py
@@ -1,0 +1,8 @@
+"""Automated evaluation harness for obs-transcriber.
+
+Measures transcription accuracy (WER) and speaker diarization accuracy (DER)
+against ground-truth meeting audio (the AMI Meeting Corpus by default), so that
+model/technique changes can be compared apples-to-apples.
+
+See evaluation/README.md and GitHub issue #2.
+"""

--- a/evaluation/datasets_ami.py
+++ b/evaluation/datasets_ami.py
@@ -20,9 +20,13 @@ committed. Nothing here imports heavy deps at module load.
 
 from __future__ import annotations
 
+import json
 import os
 import ssl
 import sys
+import time
+import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -35,10 +39,16 @@ if str(_ROOT) not in sys.path:
 from root_detection import find_project_root
 
 AMI_AUDIO_BASE = "https://groups.inf.ed.ac.uk/ami/AMICorpusMirror/amicorpus"
-RTTM_BASE = (
-    "https://raw.githubusercontent.com/pyannote/AMI-diarization-setup/main/only_words/rttms"
-)
+_SETUP_BASE = "https://raw.githubusercontent.com/pyannote/AMI-diarization-setup/main"
+RTTM_BASE = f"{_SETUP_BASE}/only_words/rttms"
+UEM_BASE = f"{_SETUP_BASE}/uems"
 RTTM_SPLITS = ("test", "dev", "train")
+
+# WER reference text: the HF datasets-server filter API over edinburghcstr/ami.
+# Pure HTTP (no `datasets` package, no audio download). The server warms up a
+# filter index on first query, briefly returning 500 / "index is loading".
+_FILTER_API = "https://datasets-server.huggingface.co/filter"
+_AMI_HF_SPLITS = ("test", "train", "validation")
 
 # Short 4-participant scenario meetings (the "a" sessions are the shortest),
 # which mirrors a typical small meeting and keeps eval runs fast.
@@ -116,52 +126,95 @@ def fetch_rttm(meeting: str, cache_dir: Path | None = None) -> Path:
     )
 
 
+def fetch_uem(meeting: str, cache_dir: Path | None = None) -> Path | None:
+    """Download the meeting's UEM (evaluation map), trying each split.
+
+    The UEM bounds the scored region so raw DER is comparable to pyannote's
+    published numbers. Returns None if unavailable (DER then falls back to the
+    union of reference+hypothesis extents).
+    """
+    cache_dir = cache_dir or default_cache_dir()
+    dest = cache_dir / "uems" / f"{meeting}.uem"
+    if dest.exists() and dest.stat().st_size > 0:
+        return dest
+    for split in RTTM_SPLITS:
+        try:
+            return _download(f"{UEM_BASE}/{split}/{meeting}.uem", dest)
+        except Exception:
+            continue
+    return None
+
+
+def _filter_query(meeting: str, split: str, offset: int, length: int,
+                  retries: int = 10, backoff: float = 8.0) -> dict:
+    """One datasets-server /filter page, retrying through transient 500s.
+
+    The server returns ``{"error": "...index is loading..."}`` (as an HTTP 500
+    body) while it warms up; we retry with backoff until it succeeds.
+    """
+    where = urllib.parse.quote(f'"meeting_id"=\'{meeting}\'')
+    url = (f"{_FILTER_API}?dataset=edinburghcstr/ami&config=ihm&split={split}"
+           f"&where={where}&offset={offset}&length={length}")
+    req = urllib.request.Request(url, headers={"User-Agent": "obs-transcriber-eval"})
+    last = {"error": "no response"}
+    for i in range(retries):
+        try:
+            with urllib.request.urlopen(req, context=_ssl_context()) as r:
+                return json.load(r)
+        except urllib.error.HTTPError as e:
+            try:
+                last = json.load(e)  # transient errors carry a JSON body
+            except Exception:
+                last = {"error": f"HTTP {e.code}"}
+        except Exception as e:
+            last = {"error": str(e)}
+        if i < retries - 1:
+            time.sleep(backoff)
+    return last
+
+
 def fetch_reference_transcript(meeting: str, cache_dir: Path | None = None) -> Path | None:
     """Build a whole-meeting reference transcript for WER, if possible.
 
-    Uses the Hugging Face ``edinburghcstr/ami`` dataset (segment text ordered by
-    start time). Returns the path to a cached ``.txt`` reference, or ``None`` if
-    the ``datasets`` package is unavailable or the meeting can't be resolved
-    (in which case WER is simply skipped).
-
-    NOTE: the exact ``edinburghcstr/ami`` schema should be validated on first
-    real run; failures here are non-fatal by design.
+    Pulls the meeting's segment texts from the HF datasets-server filter API
+    over ``edinburghcstr/ami`` (ordered by start time), trying each HF split.
+    Pure HTTP — no ``datasets`` package and no audio download. Returns the
+    cached ``.txt`` path, or ``None`` if the meeting can't be resolved (WER is
+    then simply skipped; DER still runs).
     """
     cache_dir = cache_dir or default_cache_dir()
     dest = cache_dir / "transcripts" / f"{meeting}.txt"
     if dest.exists() and dest.stat().st_size > 0:
         return dest
 
-    try:
-        from datasets import load_dataset
-    except ImportError:
-        return None
+    for split in _AMI_HF_SPLITS:
+        first = _filter_query(meeting, split, 0, 100)
+        if "error" in first:
+            return None  # API/index unavailable — non-fatal
+        total = first.get("num_rows_total") or 0
+        if total == 0:
+            continue  # meeting not in this split; try the next
 
-    try:
-        # The "ihm" config is segmented per utterance with meeting_id + timing.
-        # Stream and drop the (large) audio column so we only pull text — never
-        # the multi-GB audio. We collect every segment for this meeting, then
-        # order by start time to reconstruct the whole-meeting reference.
-        ds = load_dataset(
-            "edinburghcstr/ami", "ihm", split="test",
-            streaming=True, trust_remote_code=True,
-        )
-        if "audio" in (ds.column_names or []):
-            ds = ds.remove_columns("audio")
-        rows = [r for r in ds if r.get("meeting_id") == meeting]
-        if not rows:
-            return None
-        rows.sort(key=lambda r: float(r.get("begin_time", 0.0)))
-        text = " ".join(str(r.get("text", "")).strip() for r in rows if r.get("text"))
+        rows: list[tuple[float, str]] = []
+        offset = 0
+        while offset < total:
+            page = first if offset == 0 else _filter_query(meeting, split, offset, 100)
+            batch = page.get("rows", [])
+            if not batch:
+                break
+            for item in batch:
+                row = item.get("row", {})
+                rows.append((float(row.get("begin_time", 0.0)), row.get("text", "")))
+            offset += len(batch)
+
+        text = " ".join(t.strip() for _, t in sorted(rows) if t)
         if not text.strip():
             return None
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(text, encoding="utf-8")
         return dest
-    except Exception:
-        # Best-effort: schema/availability of the HF dataset may change. WER is
-        # skipped (DER still runs) rather than failing the whole eval.
-        return None
+
+    return None  # not found in any split
 
 
 def ensure_meeting(
@@ -180,6 +233,7 @@ def ensure_meeting(
         "meeting": meeting,
         "audio": fetch_audio(meeting, cache_dir),
         "rttm": fetch_rttm(meeting, cache_dir),
+        "uem": fetch_uem(meeting, cache_dir),
         "transcript": None,
     }
     if want_transcript:
@@ -203,4 +257,5 @@ if __name__ == "__main__":
         info = ensure_meeting(m, want_transcript=not args.no_transcript)
         print(f"  audio:      {info['audio']}")
         print(f"  rttm:       {info['rttm']}")
+        print(f"  uem:        {info['uem'] or '(unavailable — DER falls back to ref+hyp extents)'}")
         print(f"  transcript: {info['transcript'] or '(unavailable — WER will be skipped)'}")

--- a/evaluation/datasets_ami.py
+++ b/evaluation/datasets_ami.py
@@ -1,0 +1,206 @@
+"""Fetch a small, fixed subset of the AMI Meeting Corpus for evaluation.
+
+Two ground-truth sources, both freely available (CC-BY-4.0):
+
+  * Audio — the continuous mixed-headset WAV from the Edinburgh AMI mirror.
+    This is a single mixed far-field-style track of all participants, which we
+    feed to our pipeline as the "Others" track.
+
+  * Diarization reference (RTTM) — pyannote's canonical "AMI-diarization-setup"
+    (the ``only_words`` references), the same ones used for published
+    community-1 / 3.1 DER numbers, so our DER is comparable to those.
+
+  * Transcription reference (text) — OPTIONAL, via the Hugging Face
+    ``edinburghcstr/ami`` dataset (requires the ``datasets`` package). If it
+    is not installed the harness still runs DER; WER is reported as unavailable.
+
+Downloaded audio is cached under ``.eval_cache/`` (gitignored) and never
+committed. Nothing here imports heavy deps at module load.
+"""
+
+from __future__ import annotations
+
+import os
+import ssl
+import sys
+import urllib.request
+from pathlib import Path
+
+# Make project modules importable when run as a script.
+_ROOT = Path(__file__).parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+    sys.path.insert(0, str(_ROOT / "scripts"))
+
+from root_detection import find_project_root
+
+AMI_AUDIO_BASE = "https://groups.inf.ed.ac.uk/ami/AMICorpusMirror/amicorpus"
+RTTM_BASE = (
+    "https://raw.githubusercontent.com/pyannote/AMI-diarization-setup/main/only_words/rttms"
+)
+RTTM_SPLITS = ("test", "dev", "train")
+
+# Short 4-participant scenario meetings (the "a" sessions are the shortest),
+# which mirrors a typical small meeting and keeps eval runs fast.
+DEFAULT_SUBSET = ["IS1009a"]
+
+
+def default_cache_dir() -> Path:
+    """Location for cached AMI audio/references (gitignored)."""
+    return find_project_root() / ".eval_cache" / "ami"
+
+
+def audio_url(meeting: str) -> str:
+    return f"{AMI_AUDIO_BASE}/{meeting}/audio/{meeting}.Mix-Headset.wav"
+
+
+def _ssl_context() -> ssl.SSLContext:
+    """Build an SSL context that works on macOS Pythons with no system certs.
+
+    Uses the ``certifi`` CA bundle when available (the usual fix for
+    ``CERTIFICATE_VERIFY_FAILED``). Set ``EVAL_IGNORE_SSL=true`` (or the
+    project's existing ``WHISPER_IGNORE_SSL=true``) to disable verification
+    entirely, e.g. behind a TLS-intercepting corporate proxy.
+    """
+    if os.getenv("EVAL_IGNORE_SSL", "").lower() in ("true", "1", "yes") or \
+       os.getenv("WHISPER_IGNORE_SSL", "").lower() in ("true", "1", "yes"):
+        return ssl._create_unverified_context()
+    try:
+        import certifi
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except ImportError:
+        return ssl.create_default_context()
+
+
+def _download(url: str, dest: Path, *, min_bytes: int = 1) -> Path:
+    """Download ``url`` to ``dest`` unless a non-trivial file is already cached."""
+    if dest.exists() and dest.stat().st_size >= min_bytes:
+        return dest
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    req = urllib.request.Request(url, headers={"User-Agent": "obs-transcriber-eval"})
+    with urllib.request.urlopen(req, context=_ssl_context()) as resp, open(tmp, "wb") as out:
+        while True:
+            chunk = resp.read(1 << 20)  # 1 MiB
+            if not chunk:
+                break
+            out.write(chunk)
+    tmp.replace(dest)
+    return dest
+
+
+def fetch_audio(meeting: str, cache_dir: Path | None = None) -> Path:
+    """Download the meeting's mixed-headset WAV (large, ~tens of MB). Cached."""
+    cache_dir = cache_dir or default_cache_dir()
+    dest = cache_dir / "audio" / f"{meeting}.Mix-Headset.wav"
+    # Audio files are large; guard against truncated/HTML-error caches.
+    return _download(audio_url(meeting), dest, min_bytes=100_000)
+
+
+def fetch_rttm(meeting: str, cache_dir: Path | None = None) -> Path:
+    """Download the meeting's reference RTTM, trying each AMI split in turn."""
+    cache_dir = cache_dir or default_cache_dir()
+    dest = cache_dir / "rttms" / f"{meeting}.rttm"
+    if dest.exists() and dest.stat().st_size > 0:
+        return dest
+    last_err: Exception | None = None
+    for split in RTTM_SPLITS:
+        try:
+            return _download(f"{RTTM_BASE}/{split}/{meeting}.rttm", dest)
+        except Exception as e:  # try the next split
+            last_err = e
+    raise FileNotFoundError(
+        f"No reference RTTM found for meeting '{meeting}' in splits {RTTM_SPLITS}. "
+        f"Last error: {last_err}"
+    )
+
+
+def fetch_reference_transcript(meeting: str, cache_dir: Path | None = None) -> Path | None:
+    """Build a whole-meeting reference transcript for WER, if possible.
+
+    Uses the Hugging Face ``edinburghcstr/ami`` dataset (segment text ordered by
+    start time). Returns the path to a cached ``.txt`` reference, or ``None`` if
+    the ``datasets`` package is unavailable or the meeting can't be resolved
+    (in which case WER is simply skipped).
+
+    NOTE: the exact ``edinburghcstr/ami`` schema should be validated on first
+    real run; failures here are non-fatal by design.
+    """
+    cache_dir = cache_dir or default_cache_dir()
+    dest = cache_dir / "transcripts" / f"{meeting}.txt"
+    if dest.exists() and dest.stat().st_size > 0:
+        return dest
+
+    try:
+        from datasets import load_dataset
+    except ImportError:
+        return None
+
+    try:
+        # The "ihm" config is segmented per utterance with meeting_id + timing.
+        # Stream and drop the (large) audio column so we only pull text — never
+        # the multi-GB audio. We collect every segment for this meeting, then
+        # order by start time to reconstruct the whole-meeting reference.
+        ds = load_dataset(
+            "edinburghcstr/ami", "ihm", split="test",
+            streaming=True, trust_remote_code=True,
+        )
+        if "audio" in (ds.column_names or []):
+            ds = ds.remove_columns("audio")
+        rows = [r for r in ds if r.get("meeting_id") == meeting]
+        if not rows:
+            return None
+        rows.sort(key=lambda r: float(r.get("begin_time", 0.0)))
+        text = " ".join(str(r.get("text", "")).strip() for r in rows if r.get("text"))
+        if not text.strip():
+            return None
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(text, encoding="utf-8")
+        return dest
+    except Exception:
+        # Best-effort: schema/availability of the HF dataset may change. WER is
+        # skipped (DER still runs) rather than failing the whole eval.
+        return None
+
+
+def ensure_meeting(
+    meeting: str,
+    cache_dir: Path | None = None,
+    *,
+    want_transcript: bool = True,
+) -> dict:
+    """Ensure all available ground truth for a meeting is cached locally.
+
+    Returns a dict with ``audio`` and ``rttm`` paths (always) and ``transcript``
+    (a Path or None). Raises if audio or RTTM cannot be obtained.
+    """
+    cache_dir = cache_dir or default_cache_dir()
+    result = {
+        "meeting": meeting,
+        "audio": fetch_audio(meeting, cache_dir),
+        "rttm": fetch_rttm(meeting, cache_dir),
+        "transcript": None,
+    }
+    if want_transcript:
+        result["transcript"] = fetch_reference_transcript(meeting, cache_dir)
+    return result
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Pre-fetch the AMI eval subset.")
+    parser.add_argument("meetings", nargs="*", default=DEFAULT_SUBSET,
+                        help=f"Meeting IDs (default: {DEFAULT_SUBSET})")
+    parser.add_argument("--no-transcript", action="store_true",
+                        help="Skip the optional WER reference transcript")
+    args = parser.parse_args()
+
+    meetings = args.meetings or DEFAULT_SUBSET
+    for m in meetings:
+        print(f"Fetching {m} ...")
+        info = ensure_meeting(m, want_transcript=not args.no_transcript)
+        print(f"  audio:      {info['audio']}")
+        print(f"  rttm:       {info['rttm']}")
+        print(f"  transcript: {info['transcript'] or '(unavailable — WER will be skipped)'}")

--- a/evaluation/run_eval.py
+++ b/evaluation/run_eval.py
@@ -1,0 +1,226 @@
+"""Run the evaluation harness: transcribe + diarize an AMI subset, then score.
+
+Drives the *real* pipeline functions (scripts/transcribe.py, scripts/diarize.py)
+so the numbers reflect our actual settings, then computes WER and DER against
+AMI ground truth. The ASR model/backend and diarization toggle are
+configurable, so changes from issues #3-#6 can be compared apples-to-apples
+against today's baseline.
+
+Examples:
+    # Baseline: current stack on the default subset
+    python -m evaluation.run_eval
+
+    # Compare a different Whisper model, no diarization
+    python -m evaluation.run_eval --asr-model large-v3 --no-diarize
+
+    # Specific meetings, custom collar, JSON report
+    python -m evaluation.run_eval IS1009a ES2004a --collar 0.25 --json report.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+_ROOT = Path(__file__).parent.parent
+for _p in (str(_ROOT), str(_ROOT / "scripts")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from evaluation import datasets_ami, scoring
+
+
+def _transcribe(audio_path: Path, out_dir: Path, backend: str, model: str,
+                language: str, verbose: bool) -> Path:
+    """Produce an SRT for ``audio_path`` using the chosen ASR backend."""
+    if backend == "whisper":
+        import transcribe  # scripts/transcribe.py
+        return transcribe.transcribe(
+            audio_path=str(audio_path),
+            output_dir=str(out_dir),
+            model=model,
+            language=language,
+            verbose=verbose,
+        )
+    if backend == "parakeet":
+        # Placeholder for issue #4 (NVIDIA Parakeet-TDT via MLX). Once a
+        # Parakeet path exists in the pipeline, wire it in here.
+        raise NotImplementedError(
+            "Parakeet backend not implemented yet — see issue #4. Use --asr-backend whisper."
+        )
+    raise ValueError(f"Unknown ASR backend: {backend!r}")
+
+
+def run_meeting(
+    meeting: str,
+    *,
+    asr_backend: str = "whisper",
+    asr_model: str = "turbo",
+    language: str = "en",
+    do_diarize: bool = True,
+    diar_model_label: str = "pyannote/speaker-diarization-3.1",
+    hf_token: str | None = None,
+    device: str | None = None,
+    collar: float = 0.0,
+    cache_dir: Path | None = None,
+    verbose: bool = True,
+) -> dict:
+    """Run + score one meeting. Returns a result row (errors captured, not raised)."""
+    cache_dir = cache_dir or datasets_ami.default_cache_dir()
+    work_dir = cache_dir / "work" / meeting
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    row: dict = {
+        "meeting": meeting,
+        "asr_backend": asr_backend,
+        "asr_model": asr_model,
+        "diar_model": diar_model_label if do_diarize else None,
+        "wer": None,
+        "der": None,
+        "transcribe_s": None,
+        "diarize_s": None,
+        "error": None,
+    }
+
+    try:
+        info = datasets_ami.ensure_meeting(meeting, cache_dir)
+        audio = info["audio"]
+
+        # --- Transcription ---
+        t0 = time.monotonic()
+        srt_path = _transcribe(audio, work_dir, asr_backend, asr_model, language, verbose)
+        row["transcribe_s"] = round(time.monotonic() - t0, 1)
+
+        # --- WER (only if a reference transcript is available) ---
+        if info["transcript"]:
+            ref_text = Path(info["transcript"]).read_text(encoding="utf-8")
+            hyp_text = scoring.srt_to_text(srt_path)
+            row["wer"] = scoring.compute_wer(ref_text, hyp_text).as_dict()
+
+        # --- Diarization + DER ---
+        if do_diarize:
+            if not hf_token:
+                row["error"] = "diarization requested but HF_TOKEN not set; DER skipped"
+            else:
+                labeled = work_dir / f"{meeting}_labeled.srt"
+                import diarize  # scripts/diarize.py
+                t0 = time.monotonic()
+                diarize.diarize(
+                    audio_path=str(audio),
+                    srt_path=str(srt_path),
+                    output_path=str(labeled),
+                    hf_token=hf_token,
+                    device=device,
+                    verbose=verbose,
+                )
+                row["diarize_s"] = round(time.monotonic() - t0, 1)
+                ref_ann = scoring.load_rttm(info["rttm"], uri=meeting)
+                hyp_ann = scoring.srt_to_annotation(labeled, uri=meeting)
+                row["der"] = scoring.compute_der(ref_ann, hyp_ann, collar=collar).as_dict()
+    except Exception as e:  # one bad meeting shouldn't abort the whole run
+        row["error"] = f"{type(e).__name__}: {e}"
+
+    return row
+
+
+def _pct(x: float | None) -> str:
+    return f"{x * 100:.1f}%" if isinstance(x, (int, float)) else "—"
+
+
+def render_markdown(rows: list[dict]) -> str:
+    """Render results as a Markdown table."""
+    header = (
+        "| Meeting | ASR backend | ASR model | Diar model | WER | DER | Miss | FA | Conf | "
+        "Transcribe (s) | Diarize (s) |"
+    )
+    sep = "|" + "|".join(["---"] * 11) + "|"
+    lines = [header, sep]
+    for r in rows:
+        wer = r.get("wer") or {}
+        der = r.get("der") or {}
+        total = der.get("total") or 0
+        miss = der.get("missed_detection")
+        fa = der.get("false_alarm")
+        conf = der.get("confusion")
+        lines.append(
+            "| {meeting} | {backend} | {model} | {diar} | {wer} | {der} | {miss} | {fa} | {conf} | {ts} | {ds} |".format(
+                meeting=r["meeting"],
+                backend=r["asr_backend"],
+                model=r["asr_model"],
+                diar=r.get("diar_model") or "—",
+                wer=_pct(wer.get("wer")),
+                der=_pct(der.get("der")),
+                miss=_pct(miss / total) if total else "—",
+                fa=_pct(fa / total) if total else "—",
+                conf=_pct(conf / total) if total else "—",
+                ts=r.get("transcribe_s") if r.get("transcribe_s") is not None else "—",
+                ds=r.get("diarize_s") if r.get("diarize_s") is not None else "—",
+            )
+        )
+    errs = [r for r in rows if r.get("error")]
+    if errs:
+        lines.append("")
+        lines.append("**Notes / errors:**")
+        for r in errs:
+            lines.append(f"- {r['meeting']}: {r['error']}")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Evaluate the transcription/diarization pipeline against the AMI corpus.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("meetings", nargs="*", default=None,
+                        help=f"AMI meeting IDs (default: {datasets_ami.DEFAULT_SUBSET})")
+    parser.add_argument("--asr-backend", default="whisper", choices=["whisper", "parakeet"],
+                        help="ASR backend (default: whisper)")
+    parser.add_argument("--asr-model", default=os.getenv("WHISPER_MODEL", "turbo"),
+                        help="ASR model (default: $WHISPER_MODEL or 'turbo')")
+    parser.add_argument("-l", "--language", default=os.getenv("WHISPER_LANGUAGE", "en"))
+    parser.add_argument("--no-diarize", action="store_true",
+                        help="Skip diarization (WER only)")
+    parser.add_argument("--diar-model-label", default="pyannote/speaker-diarization-3.1",
+                        help="Label recorded for the diarization model in the report")
+    parser.add_argument("--hf-token", default=os.getenv("HF_TOKEN"),
+                        help="HuggingFace token for pyannote (default: $HF_TOKEN)")
+    parser.add_argument("--device", default=None, choices=["mps", "cpu"],
+                        help="Torch device for diarization (default: auto)")
+    parser.add_argument("--collar", type=float, default=0.0,
+                        help="DER collar in seconds (0.0 = strict/comparable to pyannote; "
+                             "0.25 = lenient NIST-style)")
+    parser.add_argument("--json", dest="json_out", default=None,
+                        help="Write the raw results to this JSON file")
+    parser.add_argument("-q", "--quiet", action="store_true")
+    args = parser.parse_args()
+
+    meetings = args.meetings or datasets_ami.DEFAULT_SUBSET
+    rows = []
+    for m in meetings:
+        if not args.quiet:
+            print(f"\n=== Evaluating {m} ===", file=sys.stderr)
+        rows.append(run_meeting(
+            m,
+            asr_backend=args.asr_backend,
+            asr_model=args.asr_model,
+            language=args.language,
+            do_diarize=not args.no_diarize,
+            diar_model_label=args.diar_model_label,
+            hf_token=args.hf_token,
+            device=args.device,
+            collar=args.collar,
+            verbose=not args.quiet,
+        ))
+
+    print("\n" + render_markdown(rows))
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(rows, indent=2), encoding="utf-8")
+        print(f"\nRaw results written to {args.json_out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluation/run_eval.py
+++ b/evaluation/run_eval.py
@@ -80,7 +80,8 @@ def run_meeting(
         "asr_model": asr_model,
         "diar_model": diar_model_label if do_diarize else None,
         "wer": None,
-        "der": None,
+        "der": None,        # SRT-derived labels (what the pipeline actually emits)
+        "der_raw": None,    # pyannote's native output (comparable to published DER)
         "transcribe_s": None,
         "diarize_s": None,
         "error": None,
@@ -106,21 +107,39 @@ def run_meeting(
             if not hf_token:
                 row["error"] = "diarization requested but HF_TOKEN not set; DER skipped"
             else:
-                labeled = work_dir / f"{meeting}_labeled.srt"
                 import diarize  # scripts/diarize.py
+
+                # Run the pyannote pipeline once; score both its native output
+                # and the SRT-derived labels the pipeline ultimately emits.
                 t0 = time.monotonic()
+                diar_ann = diarize.run_diarization(
+                    str(audio), hf_token, device=device, verbose=verbose
+                )
+                row["diarize_s"] = round(time.monotonic() - t0, 1)
+
+                ref_ann = scoring.load_rttm(info["rttm"], uri=meeting)
+                uem = scoring.load_uem(info["uem"], uri=meeting) if info.get("uem") else None
+
+                # Raw: pyannote's native diarization, UEM-bounded → comparable
+                # to published DER.
+                row["der_raw"] = scoring.compute_der(
+                    ref_ann, diar_ann, collar=collar, uem=uem
+                ).as_dict()
+
+                # SRT-derived: speaker labels applied to Whisper segments (the
+                # pipeline's actual transcript output), reusing the same run.
+                labeled = work_dir / f"{meeting}_labeled.srt"
                 diarize.diarize(
                     audio_path=str(audio),
                     srt_path=str(srt_path),
                     output_path=str(labeled),
-                    hf_token=hf_token,
-                    device=device,
                     verbose=verbose,
+                    diarization=diar_ann,
                 )
-                row["diarize_s"] = round(time.monotonic() - t0, 1)
-                ref_ann = scoring.load_rttm(info["rttm"], uri=meeting)
                 hyp_ann = scoring.srt_to_annotation(labeled, uri=meeting)
-                row["der"] = scoring.compute_der(ref_ann, hyp_ann, collar=collar).as_dict()
+                row["der"] = scoring.compute_der(
+                    ref_ann, hyp_ann, collar=collar, uem=uem
+                ).as_dict()
     except Exception as e:  # one bad meeting shouldn't abort the whole run
         row["error"] = f"{type(e).__name__}: {e}"
 
@@ -134,25 +153,29 @@ def _pct(x: float | None) -> str:
 def render_markdown(rows: list[dict]) -> str:
     """Render results as a Markdown table."""
     header = (
-        "| Meeting | ASR backend | ASR model | Diar model | WER | DER | Miss | FA | Conf | "
-        "Transcribe (s) | Diarize (s) |"
+        "| Meeting | ASR backend | ASR model | Diar model | WER | DER (raw) | "
+        "DER (srt) | Miss | FA | Conf | Transcribe (s) | Diarize (s) |"
     )
-    sep = "|" + "|".join(["---"] * 11) + "|"
+    sep = "|" + "|".join(["---"] * 12) + "|"
     lines = [header, sep]
     for r in rows:
         wer = r.get("wer") or {}
+        der_raw = r.get("der_raw") or {}
         der = r.get("der") or {}
-        total = der.get("total") or 0
-        miss = der.get("missed_detection")
-        fa = der.get("false_alarm")
-        conf = der.get("confusion")
+        # Miss/FA/Conf shown for the raw (native) diarization output.
+        total = der_raw.get("total") or 0
+        miss = der_raw.get("missed_detection")
+        fa = der_raw.get("false_alarm")
+        conf = der_raw.get("confusion")
         lines.append(
-            "| {meeting} | {backend} | {model} | {diar} | {wer} | {der} | {miss} | {fa} | {conf} | {ts} | {ds} |".format(
+            "| {meeting} | {backend} | {model} | {diar} | {wer} | {der_raw} | {der} | "
+            "{miss} | {fa} | {conf} | {ts} | {ds} |".format(
                 meeting=r["meeting"],
                 backend=r["asr_backend"],
                 model=r["asr_model"],
                 diar=r.get("diar_model") or "—",
                 wer=_pct(wer.get("wer")),
+                der_raw=_pct(der_raw.get("der")),
                 der=_pct(der.get("der")),
                 miss=_pct(miss / total) if total else "—",
                 fa=_pct(fa / total) if total else "—",

--- a/evaluation/scoring.py
+++ b/evaluation/scoring.py
@@ -221,6 +221,25 @@ def load_rttm(rttm_path: str | Path, uri: str | None = None) -> "Annotation":
     return annotation
 
 
+def load_uem(uem_path: str | Path, uri: str | None = None):
+    """Parse a UEM file into a pyannote Timeline (the scored region).
+
+    UEM lines: ``<file> <chan> <start> <end>``. Returns None-safe Timeline.
+    """
+    from pyannote.core import Segment, Timeline
+
+    segments = []
+    for line in Path(uem_path).read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        file_id, _chan, start, end = parts[0], parts[1], parts[2], parts[3]
+        if uri is not None and file_id != uri:
+            continue
+        segments.append(Segment(float(start), float(end)))
+    return Timeline(segments, uri=uri or Path(uem_path).stem)
+
+
 # --------------------------------------------------------------------------- #
 # DER
 # --------------------------------------------------------------------------- #

--- a/evaluation/scoring.py
+++ b/evaluation/scoring.py
@@ -1,0 +1,280 @@
+"""Scoring core for the evaluation harness.
+
+Pure, dependency-light functions for:
+  - Word Error Rate (WER) via jiwer, with meeting-appropriate text normalization.
+  - Diarization Error Rate (DER) via pyannote.metrics.
+  - Converters between the formats our pipeline emits (SRT, optionally with
+    ``[Speaker N]`` prefixes) and the formats the scorers need (plain text,
+    pyannote ``Annotation``), plus a minimal RTTM parser for ground-truth refs.
+
+Heavy imports (jiwer, pyannote) are done lazily inside the functions that need
+them so this module is cheap to import and unit-testable in isolation.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # avoid importing pyannote at module load
+    from pyannote.core import Annotation
+
+
+# Matches a leading "[Speaker 1] " style label produced by diarize.py.
+_SPEAKER_PREFIX = re.compile(r"^\[(Speaker \d+|Others|SPEAKER_\d+)\]\s*(.*)$", re.DOTALL)
+
+
+# --------------------------------------------------------------------------- #
+# WER
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class WERResult:
+    """Word-error-rate result with error breakdown."""
+
+    wer: float
+    substitutions: int
+    deletions: int
+    insertions: int
+    hits: int
+    reference_words: int
+
+    def as_dict(self) -> dict:
+        return {
+            "wer": self.wer,
+            "substitutions": self.substitutions,
+            "deletions": self.deletions,
+            "insertions": self.insertions,
+            "hits": self.hits,
+            "reference_words": self.reference_words,
+        }
+
+
+def _wer_transform():
+    """A jiwer transform: lowercase, strip punctuation, collapse whitespace.
+
+    Mirrors the normalization used by ASR leaderboards closely enough for
+    relative comparison between models (the absolute number is not directly
+    comparable to a leaderboard unless their exact normalizer is used).
+    """
+    import jiwer
+
+    return jiwer.Compose(
+        [
+            jiwer.ToLowerCase(),
+            jiwer.RemovePunctuation(),
+            jiwer.RemoveMultipleSpaces(),
+            jiwer.Strip(),
+            jiwer.ReduceToListOfListOfWords(),
+        ]
+    )
+
+
+def compute_wer(reference: str, hypothesis: str) -> WERResult:
+    """Compute WER between a reference and hypothesis transcript.
+
+    Both inputs are normalized (lowercased, depunctuated, whitespace-collapsed)
+    before scoring. An empty reference with an empty hypothesis scores 0.0; an
+    empty reference with any hypothesis scores 1.0 (all insertions).
+    """
+    import jiwer
+
+    transform = _wer_transform()
+    ref_words = transform(reference)
+    # jiwer needs at least one reference word to define WER.
+    n_ref = sum(len(s) for s in ref_words)
+    if n_ref == 0:
+        hyp_words = transform(hypothesis)
+        n_hyp = sum(len(s) for s in hyp_words)
+        return WERResult(
+            wer=0.0 if n_hyp == 0 else 1.0,
+            substitutions=0,
+            deletions=0,
+            insertions=n_hyp,
+            hits=0,
+            reference_words=0,
+        )
+
+    out = jiwer.process_words(
+        reference,
+        hypothesis,
+        reference_transform=transform,
+        hypothesis_transform=transform,
+    )
+    return WERResult(
+        wer=out.wer,
+        substitutions=out.substitutions,
+        deletions=out.deletions,
+        insertions=out.insertions,
+        hits=out.hits,
+        reference_words=n_ref,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# SRT helpers
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class Cue:
+    """A single transcript cue with timing, optional speaker label, and text."""
+
+    start: float  # seconds
+    end: float  # seconds
+    text: str
+    speaker: str | None = None
+
+
+def parse_srt(srt_path: str | Path) -> list[Cue]:
+    """Parse an SRT file into cues, splitting off any ``[Speaker N]`` prefix.
+
+    Returns an empty list for an empty/whitespace-only file.
+    """
+    import srt as srt_lib
+
+    raw = Path(srt_path).read_text(encoding="utf-8")
+    if not raw.strip():
+        return []
+
+    cues: list[Cue] = []
+    for sub in srt_lib.parse(raw):
+        content = sub.content.strip()
+        speaker = None
+        m = _SPEAKER_PREFIX.match(content)
+        if m:
+            speaker = m.group(1)
+            content = m.group(2).strip()
+        cues.append(
+            Cue(
+                start=sub.start.total_seconds(),
+                end=sub.end.total_seconds(),
+                text=content,
+                speaker=speaker,
+            )
+        )
+    return cues
+
+
+def srt_to_text(srt_path: str | Path) -> str:
+    """Concatenate an SRT file's cues into one transcript string for WER.
+
+    Any ``[Speaker N]`` prefixes are stripped (handled by parse_srt).
+    """
+    return " ".join(c.text for c in parse_srt(srt_path) if c.text)
+
+
+def cues_to_annotation(cues: list[Cue], uri: str = "audio") -> "Annotation":
+    """Build a pyannote Annotation from cues, using their speaker labels.
+
+    Cues without a speaker label are assigned a single shared "UNKNOWN" label.
+    """
+    from pyannote.core import Annotation, Segment
+
+    annotation = Annotation(uri=uri)
+    for i, cue in enumerate(cues):
+        if cue.end <= cue.start:
+            continue
+        label = cue.speaker if cue.speaker else "UNKNOWN"
+        annotation[Segment(cue.start, cue.end), i] = label
+    return annotation
+
+
+def srt_to_annotation(srt_path: str | Path, uri: str = "audio") -> "Annotation":
+    """Parse a (diarized) SRT file directly into a pyannote Annotation."""
+    return cues_to_annotation(parse_srt(srt_path), uri=uri)
+
+
+# --------------------------------------------------------------------------- #
+# RTTM (ground-truth diarization references)
+# --------------------------------------------------------------------------- #
+
+def load_rttm(rttm_path: str | Path, uri: str | None = None) -> "Annotation":
+    """Parse an NIST RTTM file into a single pyannote Annotation.
+
+    RTTM ``SPEAKER`` lines look like::
+
+        SPEAKER <file> <chan> <start> <dur> <NA> <NA> <speaker> <NA> <NA>
+
+    Lines for other file ids are skipped when ``uri`` is given; otherwise all
+    SPEAKER lines are merged into one annotation.
+    """
+    from pyannote.core import Annotation, Segment
+
+    annotation = Annotation(uri=uri or Path(rttm_path).stem)
+    idx = 0
+    for line in Path(rttm_path).read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        if not parts or parts[0] != "SPEAKER":
+            continue
+        file_id, _chan, start, dur = parts[1], parts[2], parts[3], parts[4]
+        speaker = parts[7]
+        if uri is not None and file_id != uri:
+            continue
+        start_f = float(start)
+        dur_f = float(dur)
+        if dur_f <= 0:
+            continue
+        annotation[Segment(start_f, start_f + dur_f), idx] = speaker
+        idx += 1
+    return annotation
+
+
+# --------------------------------------------------------------------------- #
+# DER
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class DERResult:
+    """Diarization-error-rate result with its standard components (seconds)."""
+
+    der: float
+    missed_detection: float
+    false_alarm: float
+    confusion: float
+    total: float
+    collar: float = 0.0
+    skip_overlap: bool = False
+
+    def as_dict(self) -> dict:
+        return {
+            "der": self.der,
+            "missed_detection": self.missed_detection,
+            "false_alarm": self.false_alarm,
+            "confusion": self.confusion,
+            "total": self.total,
+            "collar": self.collar,
+            "skip_overlap": self.skip_overlap,
+        }
+
+
+def compute_der(
+    reference: "Annotation",
+    hypothesis: "Annotation",
+    collar: float = 0.0,
+    skip_overlap: bool = False,
+    uem=None,
+) -> DERResult:
+    """Compute DER between reference and hypothesis pyannote Annotations.
+
+    Defaults (collar=0.0, skip_overlap=False) match the "fair" no-forgiveness
+    setting pyannote uses for its published community-1/3.1 benchmark numbers,
+    so results here are directly comparable to those. Pass collar=0.25 to
+    reproduce the older, more lenient NIST-style scoring.
+    """
+    from pyannote.metrics.diarization import DiarizationErrorRate
+
+    metric = DiarizationErrorRate(collar=collar, skip_overlap=skip_overlap)
+    components = metric(reference, hypothesis, uem=uem, detailed=True)
+    total = components["total"]
+    der = components["diarization error rate"]
+    return DERResult(
+        der=der,
+        missed_detection=components["missed detection"],
+        false_alarm=components["false alarm"],
+        confusion=components["confusion"],
+        total=total,
+        collar=collar,
+        skip_overlap=skip_overlap,
+    )

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ python_functions = test_*
 markers =
     unit: Fast unit tests (run always)
     integration: Slow integration tests (run in CI)
+    eval: Evaluation harness E2E (downloads AMI audio + runs models; opt-in via RUN_EVAL=1)
 addopts =
     --verbose
     --strict-markers

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ pyobjc-framework-EventKit>=10.0
 pytest>=9.0
 pytest-cov>=7.0
 # Evaluation harness (see evaluation/) — WER scoring. pyannote.metrics (DER)
-# ships with pyannote.audio above. The optional WER reference transcript also
-# needs `datasets` (pip install datasets), kept out of the default install.
+# ships with pyannote.audio above; the WER reference transcript is fetched over
+# plain HTTP (HF datasets-server), so no extra dataset library is required.
 jiwer>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,8 @@ tzlocal
 requests
 pyobjc-framework-EventKit>=10.0
 pytest>=9.0
-pytest-cov>=7.0 
+pytest-cov>=7.0
+# Evaluation harness (see evaluation/) — WER scoring. pyannote.metrics (DER)
+# ships with pyannote.audio above. The optional WER reference transcript also
+# needs `datasets` (pip install datasets), kept out of the default install.
+jiwer>=3.0

--- a/scripts/diarize.py
+++ b/scripts/diarize.py
@@ -57,39 +57,35 @@ def _human_label(raw_speaker: str, speaker_map: dict) -> str:
     return speaker_map[raw_speaker]
 
 
-def diarize(
+# Diarization model. Bumping this (e.g. to speaker-diarization-community-1 in #3)
+# updates both the production pipeline and the evaluation harness in one place.
+DIARIZATION_MODEL = "pyannote/speaker-diarization-3.1"
+
+
+def run_diarization(
     audio_path: str,
-    srt_path: str,
-    output_path: str,
     hf_token: str,
     device: str | None = None,
     verbose: bool = True,
-) -> Path:
+):
     """
-    Run speaker diarization on audio and apply speaker labels to an SRT transcript.
+    Run the pyannote diarization pipeline and return the raw result.
 
-    For each SRT segment, finds the pyannote speaker with the greatest temporal
-    overlap and prepends a [Speaker N] label to the subtitle content.
+    Separated from label application so callers (e.g. the evaluation harness)
+    can score pyannote's native output directly without re-running the model.
 
     Args:
         audio_path: Path to the audio WAV file (16 kHz mono is ideal)
-        srt_path: Path to the existing SRT transcript to label
-        output_path: Destination path for the labeled SRT file
         hf_token: HuggingFace access token for pyannote model download
         device: Torch device ('mps' or 'cpu'). Auto-detected if None.
         verbose: Whether to print progress information
 
     Returns:
-        Path to the labeled output SRT file
+        A pyannote.core.Annotation with the diarization result.
     """
     audio_path = Path(audio_path)
-    srt_path = Path(srt_path)
-    output_path = Path(output_path)
-
     if not audio_path.exists():
         raise FileNotFoundError(f"Audio file not found: {audio_path}")
-    if not srt_path.exists():
-        raise FileNotFoundError(f"SRT file not found: {srt_path}")
 
     # Auto-select device: prefer MPS (Apple Silicon GPU), fall back to CPU
     if device is None:
@@ -98,10 +94,10 @@ def diarize(
 
     if verbose:
         print(f"🎙️  Device: {device}")
-        print("⏳ Loading pyannote speaker diarization pipeline...")
+        print(f"⏳ Loading pyannote speaker diarization pipeline ({DIARIZATION_MODEL})...")
 
     pipeline = Pipeline.from_pretrained(
-        "pyannote/speaker-diarization-3.1",
+        DIARIZATION_MODEL,
         use_auth_token=hf_token,
     )
     pipeline.to(torch_device)
@@ -116,6 +112,51 @@ def diarize(
     )
     if verbose:
         print(f"✅ Detected {len(detected_speakers)} speaker(s): {', '.join(detected_speakers)}")
+
+    return diarization_result
+
+
+def diarize(
+    audio_path: str,
+    srt_path: str,
+    output_path: str,
+    hf_token: str = None,
+    device: str | None = None,
+    verbose: bool = True,
+    diarization=None,
+) -> Path:
+    """
+    Run speaker diarization on audio and apply speaker labels to an SRT transcript.
+
+    For each SRT segment, finds the pyannote speaker with the greatest temporal
+    overlap and prepends a [Speaker N] label to the subtitle content.
+
+    Args:
+        audio_path: Path to the audio WAV file (16 kHz mono is ideal)
+        srt_path: Path to the existing SRT transcript to label
+        output_path: Destination path for the labeled SRT file
+        hf_token: HuggingFace access token for pyannote model download
+        device: Torch device ('mps' or 'cpu'). Auto-detected if None.
+        verbose: Whether to print progress information
+        diarization: Optional precomputed diarization Annotation (from
+            run_diarization). If provided, the model is not re-run.
+
+    Returns:
+        Path to the labeled output SRT file
+    """
+    audio_path = Path(audio_path)
+    srt_path = Path(srt_path)
+    output_path = Path(output_path)
+
+    if not audio_path.exists():
+        raise FileNotFoundError(f"Audio file not found: {audio_path}")
+    if not srt_path.exists():
+        raise FileNotFoundError(f"SRT file not found: {srt_path}")
+
+    if diarization is None:
+        diarization_result = run_diarization(audio_path, hf_token, device, verbose)
+    else:
+        diarization_result = diarization
 
     with open(srt_path, "r", encoding="utf-8") as f:
         subtitles = list(srt.parse(f.read()))

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -1,0 +1,62 @@
+"""End-to-end evaluation-harness tests.
+
+These are opt-in: they download AMI data from the network and (for the full
+run) load ASR/diarization models. They are skipped unless ``RUN_EVAL=1`` so the
+default fast suite stays hermetic.
+
+Run them with:
+    RUN_EVAL=1 python -m pytest tests/test_eval_harness.py -m eval -s
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_project_root = Path(__file__).parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+pytestmark = [
+    pytest.mark.eval,
+    pytest.mark.skipif(os.getenv("RUN_EVAL") != "1", reason="set RUN_EVAL=1 to run eval E2E"),
+]
+
+from evaluation import datasets_ami, scoring
+
+
+def test_fetch_rttm_and_score(tmp_path):
+    """Cheap check: RTTM download + parse + DER integration (no audio/models)."""
+    meeting = datasets_ami.DEFAULT_SUBSET[0]
+    rttm = datasets_ami.fetch_rttm(meeting, cache_dir=tmp_path)
+    assert rttm.exists() and rttm.stat().st_size > 0
+
+    ref = scoring.load_rttm(rttm, uri=meeting)
+    assert len(ref.labels()) >= 2  # AMI scenario meetings have multiple speakers
+
+    # Scoring the reference against itself must be a perfect score.
+    res = scoring.compute_der(ref, ref)
+    assert res.der == pytest.approx(0.0)
+    assert res.total > 0
+
+
+@pytest.mark.skipif(os.getenv("RUN_EVAL_FULL") != "1",
+                    reason="set RUN_EVAL_FULL=1 to run the full transcribe+diarize E2E")
+def test_full_pipeline_eval():
+    """Full run on the default subset; asserts the numbers are at least plausible."""
+    from evaluation.run_eval import run_meeting
+
+    meeting = datasets_ami.DEFAULT_SUBSET[0]
+    row = run_meeting(
+        meeting,
+        asr_model=os.getenv("WHISPER_MODEL", "turbo"),
+        do_diarize=bool(os.getenv("HF_TOKEN")),
+        hf_token=os.getenv("HF_TOKEN"),
+        verbose=True,
+    )
+    assert row["error"] is None, row["error"]
+    if row["wer"] is not None:
+        assert 0.0 <= row["wer"]["wer"] < 1.0
+    if row["der"] is not None:
+        assert 0.0 <= row["der"]["der"] < 1.0

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -58,5 +58,6 @@ def test_full_pipeline_eval():
     assert row["error"] is None, row["error"]
     if row["wer"] is not None:
         assert 0.0 <= row["wer"]["wer"] < 1.0
-    if row["der"] is not None:
-        assert 0.0 <= row["der"]["der"] < 1.0
+    for key in ("der", "der_raw"):
+        if row[key] is not None:
+            assert 0.0 <= row[key]["der"] < 1.0

--- a/tests/test_eval_scoring.py
+++ b/tests/test_eval_scoring.py
@@ -1,0 +1,170 @@
+"""Unit tests for the evaluation scoring core (evaluation/scoring.py).
+
+These use only synthetic, in-memory data — no audio downloads, models, or
+network — so they run as part of the default fast suite.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_project_root = Path(__file__).parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+from evaluation import scoring
+
+
+# --------------------------------------------------------------------------- #
+# WER
+# --------------------------------------------------------------------------- #
+
+class TestWER:
+    def test_perfect_match_is_zero(self):
+        r = scoring.compute_wer("the quick brown fox", "the quick brown fox")
+        assert r.wer == 0.0
+        assert r.substitutions == r.deletions == r.insertions == 0
+        assert r.hits == 4
+
+    def test_normalization_ignores_case_and_punctuation(self):
+        r = scoring.compute_wer("The Quick, Brown Fox.", "the quick brown fox")
+        assert r.wer == 0.0
+
+    def test_one_substitution(self):
+        r = scoring.compute_wer("the cat sat", "the cat sit")
+        assert r.substitutions == 1
+        assert r.wer == pytest.approx(1 / 3)
+        assert r.reference_words == 3
+
+    def test_deletion_and_insertion(self):
+        # reference has 3 words, hypothesis drops one and adds one elsewhere
+        r = scoring.compute_wer("alpha beta gamma", "alpha gamma delta")
+        assert r.reference_words == 3
+        assert r.wer > 0
+
+    def test_empty_reference_empty_hyp(self):
+        r = scoring.compute_wer("", "")
+        assert r.wer == 0.0
+
+    def test_empty_reference_nonempty_hyp(self):
+        r = scoring.compute_wer("", "hello world")
+        assert r.wer == 1.0
+        assert r.insertions == 2
+
+
+# --------------------------------------------------------------------------- #
+# SRT parsing
+# --------------------------------------------------------------------------- #
+
+_PLAIN_SRT = """1
+00:00:00,000 --> 00:00:02,000
+Hello there.
+
+2
+00:00:03,000 --> 00:00:05,000
+General Kenobi.
+"""
+
+_DIARIZED_SRT = """1
+00:00:00,000 --> 00:00:02,000
+[Speaker 1] Hello there.
+
+2
+00:00:03,000 --> 00:00:05,000
+[Speaker 2] General Kenobi.
+"""
+
+
+class TestSRT:
+    def test_parse_plain_srt(self, tmp_path):
+        p = tmp_path / "a.srt"
+        p.write_text(_PLAIN_SRT, encoding="utf-8")
+        cues = scoring.parse_srt(p)
+        assert len(cues) == 2
+        assert cues[0].start == 0.0 and cues[0].end == 2.0
+        assert cues[0].text == "Hello there."
+        assert cues[0].speaker is None
+
+    def test_parse_diarized_srt_extracts_speaker(self, tmp_path):
+        p = tmp_path / "b.srt"
+        p.write_text(_DIARIZED_SRT, encoding="utf-8")
+        cues = scoring.parse_srt(p)
+        assert cues[0].speaker == "Speaker 1"
+        assert cues[0].text == "Hello there."
+        assert cues[1].speaker == "Speaker 2"
+
+    def test_empty_srt_returns_no_cues(self, tmp_path):
+        p = tmp_path / "empty.srt"
+        p.write_text("", encoding="utf-8")
+        assert scoring.parse_srt(p) == []
+
+    def test_srt_to_text_strips_speaker_prefix(self, tmp_path):
+        p = tmp_path / "c.srt"
+        p.write_text(_DIARIZED_SRT, encoding="utf-8")
+        assert scoring.srt_to_text(p) == "Hello there. General Kenobi."
+
+
+# --------------------------------------------------------------------------- #
+# RTTM + DER
+# --------------------------------------------------------------------------- #
+
+def _rttm(uri: str, turns) -> str:
+    return "\n".join(
+        f"SPEAKER {uri} 1 {start:.3f} {dur:.3f} <NA> <NA> {spk} <NA> <NA>"
+        for (start, dur, spk) in turns
+    )
+
+
+class TestDER:
+    def test_load_rttm(self, tmp_path):
+        p = tmp_path / "m.rttm"
+        p.write_text(_rttm("m", [(0.0, 5.0, "A"), (5.0, 5.0, "B")]), encoding="utf-8")
+        ann = scoring.load_rttm(p, uri="m")
+        assert set(ann.labels()) == {"A", "B"}
+        assert ann.get_timeline().duration() == pytest.approx(10.0)
+
+    def test_perfect_diarization_is_zero_der(self, tmp_path):
+        ref_p = tmp_path / "ref.rttm"
+        ref_p.write_text(_rttm("m", [(0.0, 5.0, "A"), (5.0, 5.0, "B")]), encoding="utf-8")
+        ref = scoring.load_rttm(ref_p, uri="m")
+        # Hypothesis uses different label names but identical segmentation.
+        hyp_p = tmp_path / "hyp.rttm"
+        hyp_p.write_text(_rttm("m", [(0.0, 5.0, "X"), (5.0, 5.0, "Y")]), encoding="utf-8")
+        hyp = scoring.load_rttm(hyp_p, uri="m")
+        res = scoring.compute_der(ref, hyp)
+        assert res.der == pytest.approx(0.0)
+        assert res.total == pytest.approx(10.0)
+
+    def test_missed_detection_half(self, tmp_path):
+        ref_p = tmp_path / "ref.rttm"
+        ref_p.write_text(_rttm("m", [(0.0, 10.0, "A")]), encoding="utf-8")
+        ref = scoring.load_rttm(ref_p, uri="m")
+        hyp_p = tmp_path / "hyp.rttm"
+        hyp_p.write_text(_rttm("m", [(0.0, 5.0, "A")]), encoding="utf-8")
+        hyp = scoring.load_rttm(hyp_p, uri="m")
+        res = scoring.compute_der(ref, hyp)
+        assert res.der == pytest.approx(0.5)
+        assert res.missed_detection == pytest.approx(5.0)
+        assert res.false_alarm == pytest.approx(0.0)
+
+    def test_speaker_confusion(self, tmp_path):
+        # Reference: two speakers; hypothesis collapses them into one → confusion.
+        ref_p = tmp_path / "ref.rttm"
+        ref_p.write_text(_rttm("m", [(0.0, 5.0, "A"), (5.0, 5.0, "B")]), encoding="utf-8")
+        ref = scoring.load_rttm(ref_p, uri="m")
+        hyp_p = tmp_path / "hyp.rttm"
+        hyp_p.write_text(_rttm("m", [(0.0, 10.0, "A")]), encoding="utf-8")
+        hyp = scoring.load_rttm(hyp_p, uri="m")
+        res = scoring.compute_der(ref, hyp)
+        # Half the time is attributed to the wrong speaker.
+        assert res.confusion == pytest.approx(5.0)
+        assert res.der == pytest.approx(0.5)
+
+    def test_srt_to_annotation_roundtrip_der(self, tmp_path):
+        p = tmp_path / "b.srt"
+        p.write_text(_DIARIZED_SRT, encoding="utf-8")
+        ann = scoring.srt_to_annotation(p)
+        # Scoring an annotation against itself is a perfect score.
+        res = scoring.compute_der(ann, ann)
+        assert res.der == pytest.approx(0.0)

--- a/tests/test_eval_scoring.py
+++ b/tests/test_eval_scoring.py
@@ -168,3 +168,19 @@ class TestDER:
         # Scoring an annotation against itself is a perfect score.
         res = scoring.compute_der(ann, ann)
         assert res.der == pytest.approx(0.0)
+
+    def test_uem_bounds_scored_region(self, tmp_path):
+        # Reference speaks 0-10s; hypothesis only covers 0-5s (misses 5-10s).
+        ref_p = tmp_path / "ref.rttm"
+        ref_p.write_text(_rttm("m", [(0.0, 10.0, "A")]), encoding="utf-8")
+        ref = scoring.load_rttm(ref_p, uri="m")
+        hyp_p = tmp_path / "hyp.rttm"
+        hyp_p.write_text(_rttm("m", [(0.0, 5.0, "A")]), encoding="utf-8")
+        hyp = scoring.load_rttm(hyp_p, uri="m")
+        # A UEM that only scores 0-5s should exclude the missed region → DER 0.
+        uem_p = tmp_path / "m.uem"
+        uem_p.write_text("m 1 0.000 5.000\n", encoding="utf-8")
+        uem = scoring.load_uem(uem_p, uri="m")
+        res = scoring.compute_der(ref, hyp, uem=uem)
+        assert res.der == pytest.approx(0.0)
+        assert res.total == pytest.approx(5.0)


### PR DESCRIPTION
## What

Adds an automated, reproducible **evaluation harness** that measures the pipeline's transcription accuracy (**WER**) and speaker diarization accuracy (**DER**) against ground-truth meeting audio, so the model/technique changes in #3–#6 can be compared apples-to-apples instead of eyeballed.

Implements #2.

## Why the AMI Meeting Corpus

[AMI](https://groups.inf.ed.ac.uk/ami/corpus/) is the standard public (CC-BY-4.0) multi-participant meeting dataset and maps onto our architecture: continuous mixed-headset audio (→ our "Others" track) plus ground truth for **both** metrics (manual transcripts → WER, speaker segmentation → DER). It's the same reference behind published community-1 / 3.1 DER numbers, so our DER is comparable. Audio is downloaded on demand into `.eval_cache/` (gitignored — never committed).

## Contents

| File | Role |
|---|---|
| `evaluation/scoring.py` | Pure WER (jiwer) + DER (pyannote.metrics) + SRT/RTTM converters |
| `evaluation/datasets_ami.py` | Fetch a fixed AMI subset (audio mirror + pyannote `AMI-diarization-setup` RTTM) |
| `evaluation/run_eval.py` | Orchestrator/CLI driving the **real** pipeline (`transcribe.py`/`diarize.py`) then scoring |
| `evaluation/README.md` | Setup / usage / limitations |
| `tests/test_eval_scoring.py` | 15 hermetic scoring unit tests (run in default suite) |
| `tests/test_eval_harness.py` | Opt-in E2E (`RUN_EVAL=1`), `eval` marker |

## Usage

```bash
pip install -r requirements.txt          # adds jiwer
python -m evaluation.run_eval --json baseline.json   # current stack on default subset
python -m evaluation.run_eval --asr-model large-v3 --no-diarize   # WER only, no HF token
```

Configurable `--asr-backend` / `--asr-model` / `--diar-model-label` / `--collar` let #3–#6 be compared against the recorded baseline. The `parakeet` ASR branch is stubbed for #4.

## Verification

- `pytest`: **71 passed, 2 skipped** (eval E2E skipped by default).
- Scoring core proven against synthetic WER/DER cases with known values.
- Dataset → scoring path proven against **real AMI ground truth** (`IS1009a.rttm` downloaded, parsed, scored).
- Fixed a real macOS SSL `CERTIFICATE_VERIFY_FAILED` (downloader now uses `certifi`; `EVAL_IGNORE_SSL` fallback, consistent with `WHISPER_IGNORE_SSL`).

## Notes

- Baseline numbers for today's stack will be posted to #2 (separate one-time data run; the DER half needs `HF_TOKEN` + accepted pyannote licenses).
- WER auto-reference is best-effort via the optional `datasets` package; if unavailable the harness reports WER as `—` and still produces DER.
- Also includes a small docs commit documenting the `web/` app in `CLAUDE.md` (from prior work, kept as its own commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
