### PR TITLE
feat(diarize): upgrade to pyannote speaker-diarization-community-1 (closes #3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,10 +119,9 @@ KEEP_RAW_RECORDING=false
 # Requires HF_TOKEN to be set (see below).
 # One-time setup:
 #   1. Create a HuggingFace account at https://huggingface.co
-#   2. Accept the model license: https://huggingface.co/pyannote/speaker-diarization-3.1
-#   3. Accept the model license: https://huggingface.co/pyannote/segmentation-3.0
-#   4. Generate a read token: https://huggingface.co/settings/tokens
-#   5. Paste the token as HF_TOKEN below and set ENABLE_DIARIZATION=true
+#   2. Accept the model conditions: https://huggingface.co/pyannote/speaker-diarization-community-1
+#   3. Generate a read token: https://huggingface.co/settings/tokens
+#   4. Paste the token as HF_TOKEN below and set ENABLE_DIARIZATION=true
 # ENABLE_DIARIZATION=false
 
 # OPTIONAL

--- a/README.md
+++ b/README.md
@@ -53,10 +53,9 @@ Before you begin, ensure you have the following installed:
     Speaker diarization identifies individual speakers in the "Others" track (e.g. "Speaker 1", "Speaker 2"). It is disabled by default and requires a one-time HuggingFace setup:
 
     1. Create a HuggingFace account at <https://huggingface.co>
-    2. Accept the model license: <https://huggingface.co/pyannote/speaker-diarization-3.1>
-    3. Accept the model license: <https://huggingface.co/pyannote/segmentation-3.0>
-    4. Generate a read token: <https://huggingface.co/settings/tokens>
-    5. Add the following to your `.env` file:
+    2. Accept the model conditions: <https://huggingface.co/pyannote/speaker-diarization-community-1>
+    3. Generate a read token: <https://huggingface.co/settings/tokens>
+    4. Add the following to your `.env` file:
 
     ```ini
     ENABLE_DIARIZATION=true

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -80,8 +80,10 @@ and the harness together.
 
 ### Comparing changes (#3–#6)
 
-- **#3 diarization model**: after pointing `scripts/diarize.py` at
-  `community-1`, re-run and pass `--diar-model-label pyannote/speaker-diarization-community-1`.
+- **#3 diarization model**: A/B without editing code by overriding the model via
+  the `DIARIZATION_MODEL` env var, e.g.
+  `DIARIZATION_MODEL=pyannote/speaker-diarization-3.1 python -m evaluation.run_eval IS1009a --diar-model-label pyannote/speaker-diarization-3.1`.
+  Default is `community-1`.
 - **#4 Parakeet ASR**: implement the `parakeet` branch in `run_eval._transcribe`,
   then `--asr-backend parakeet`.
 - **#5 VAD / #6 word-level assignment**: changes land in the pipeline; just re-run

--- a/evaluation/run_eval.py
+++ b/evaluation/run_eval.py
@@ -62,7 +62,7 @@ def run_meeting(
     asr_model: str = "turbo",
     language: str = "en",
     do_diarize: bool = True,
-    diar_model_label: str = "pyannote/speaker-diarization-3.1",
+    diar_model_label: str | None = None,
     hf_token: str | None = None,
     device: str | None = None,
     collar: float = 0.0,
@@ -78,7 +78,8 @@ def run_meeting(
         "meeting": meeting,
         "asr_backend": asr_backend,
         "asr_model": asr_model,
-        "diar_model": diar_model_label if do_diarize else None,
+        # Resolved to the model that actually ran in the diarization branch below.
+        "diar_model": None,
         "wer": None,
         "der": None,        # SRT-derived labels (what the pipeline actually emits)
         "der_raw": None,    # pyannote's native output (comparable to published DER)
@@ -108,6 +109,10 @@ def run_meeting(
                 row["error"] = "diarization requested but HF_TOKEN not set; DER skipped"
             else:
                 import diarize  # scripts/diarize.py
+
+                # Label the report with the model that actually ran (honors the
+                # DIARIZATION_MODEL env override) unless one was explicitly given.
+                row["diar_model"] = diar_model_label or diarize.DIARIZATION_MODEL
 
                 # Run the pyannote pipeline once; score both its native output
                 # and the SRT-derived labels the pipeline ultimately emits.
@@ -207,8 +212,10 @@ def main():
     parser.add_argument("-l", "--language", default=os.getenv("WHISPER_LANGUAGE", "en"))
     parser.add_argument("--no-diarize", action="store_true",
                         help="Skip diarization (WER only)")
-    parser.add_argument("--diar-model-label", default="pyannote/speaker-diarization-3.1",
-                        help="Label recorded for the diarization model in the report")
+    parser.add_argument("--diar-model-label", default=None,
+                        help="Label recorded for the diarization model in the report "
+                             "(default: the model that actually ran, i.e. "
+                             "diarize.DIARIZATION_MODEL)")
     parser.add_argument("--hf-token", default=os.getenv("HF_TOKEN"),
                         help="HuggingFace token for pyannote (default: $HF_TOKEN)")
     parser.add_argument("--device", default=None, choices=["mps", "cpu"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ obsws-python
 srt
 python-dotenv
 colorama>=0.4.6
-pyannote.audio>=2.1.0
+pyannote.audio>=4.0  # speaker-diarization-community-1 requires 4.x
+speechbrain>=1.1.0   # 1.1.0 supports torchaudio>=2.9 (older versions call the removed list_audio_backends)
 torch>=1.9.0
 flask>=3.0
 icalendar>=5.0.0

--- a/scripts/diarize.py
+++ b/scripts/diarize.py
@@ -57,9 +57,14 @@ def _human_label(raw_speaker: str, speaker_map: dict) -> str:
     return speaker_map[raw_speaker]
 
 
-# Diarization model. Bumping this (e.g. to speaker-diarization-community-1 in #3)
-# updates both the production pipeline and the evaluation harness in one place.
-DIARIZATION_MODEL = "pyannote/speaker-diarization-3.1"
+# Diarization model. Defined once so both the production pipeline and the
+# evaluation harness stay in sync. Requires pyannote.audio 4.x. The model is
+# gated on HuggingFace — accept its conditions at
+# https://huggingface.co/pyannote/speaker-diarization-community-1
+# Overridable via DIARIZATION_MODEL env var (handy for A/B-ing models in eval).
+DIARIZATION_MODEL = os.environ.get(
+    "DIARIZATION_MODEL", "pyannote/speaker-diarization-community-1"
+)
 
 
 def run_diarization(
@@ -98,14 +103,17 @@ def run_diarization(
 
     pipeline = Pipeline.from_pretrained(
         DIARIZATION_MODEL,
-        use_auth_token=hf_token,
+        token=hf_token,  # pyannote.audio 4.x renamed use_auth_token -> token
     )
     pipeline.to(torch_device)
 
     if verbose:
         print(f"⏳ Running diarization on: {audio_path.name}")
 
-    diarization_result = pipeline(str(audio_path))
+    output = pipeline(str(audio_path))
+    # pyannote.audio 4.x returns a result object whose Annotation is exposed as
+    # `.speaker_diarization`; 3.x returned the Annotation directly. Support both.
+    diarization_result = getattr(output, "speaker_diarization", output)
 
     detected_speakers = sorted(
         {speaker for _, _, speaker in diarization_result.itertracks(yield_label=True)}
@@ -200,10 +208,9 @@ def main():
         epilog="""
 One-time setup:
   1. Create a HuggingFace account at https://huggingface.co
-  2. Accept the model license at https://huggingface.co/pyannote/speaker-diarization-3.1
-  3. Accept the model license at https://huggingface.co/pyannote/segmentation-3.0
-  4. Generate a read token at https://huggingface.co/settings/tokens
-  5. Add HF_TOKEN=<your_token> to your .env file
+  2. Accept the model conditions at https://huggingface.co/pyannote/speaker-diarization-community-1
+  3. Generate a read token at https://huggingface.co/settings/tokens
+  4. Add HF_TOKEN=<your_token> to your .env file
 
 Examples:
   %(prog)s others.wav others.srt -o others_labeled.srt
@@ -235,9 +242,8 @@ Examples:
             "❌ Error: HuggingFace token required for pyannote model access.\n"
             "   Set HF_TOKEN=<token> in your .env file, or pass --token <token>.\n"
             "   Get a token at: https://huggingface.co/settings/tokens\n"
-            "   Accept model licenses at:\n"
-            "     https://huggingface.co/pyannote/speaker-diarization-3.1\n"
-            "     https://huggingface.co/pyannote/segmentation-3.0",
+            "   Accept the model conditions at:\n"
+            "     https://huggingface.co/pyannote/speaker-diarization-community-1",
             file=sys.stderr,
         )
         sys.exit(1)


### PR DESCRIPTION
## What

Upgrades speaker diarization from `pyannote/speaker-diarization-3.1` to its maintained successor **`pyannote/speaker-diarization-community-1`** (requires pyannote.audio 4.x). Closes #3.

## Results (measured via the eval harness from #2)

3-meeting AMI sample, Mix-Headset, strict scoring (`collar=0.0`), DER on pyannote's native output:

| Meeting | DER raw 3.1 | DER raw community-1 | Confusion 3.1→c1 |
|---|---|---|---|
| IS1009a | 20.4% | **19.7%** | 6.3% → 5.6% |
| ES2004a | **18.1%** | 18.8% | 2.5% → 3.1% |
| TS3003a | 19.0% | **17.1%** | 4.7% → 2.9% |
| **Average** | **19.2%** | **18.5%** | 4.5% → 3.9% |

- **~0.7pt lower average DER (raw)** and **lower average speaker confusion**.
- **Correct speaker count** on IS1009a (4 vs 3.1's 5).
- **Comparable speed** (community-1 was actually faster on ES2004a).
- Per-meeting variance means it's not a clean sweep (ES2004a marginally worse), but the average + the fact that 3.1 is superseded justify the swap. WER is unchanged (transcription untouched).

## Changes

- `scripts/diarize.py`: model → community-1 (overridable via `DIARIZATION_MODEL` env var for A/B), pyannote.audio 4.x API migration (`use_auth_token`→`token`, handle the new `.speaker_diarization` output wrapper). Model defined once, shared with the harness.
- `requirements.txt`: `pyannote.audio>=4.0`; **`speechbrain>=1.1.0`** — older speechbrain calls `torchaudio.list_audio_backends`, removed in torchaudio ≥2.9 (which pyannote 4.x pulls in). This was a real install-breaker caught during testing.
- Docs (`diarize.py` help, `.env.example`, `README.md`): community-1 is a **single gated model** — no separate `segmentation-3.0` acceptance needed.

## Setup note for reviewers

community-1 is gated: accept its conditions once at <https://huggingface.co/pyannote/speaker-diarization-community-1> with the account behind your `HF_TOKEN` (auto-granted). Existing token works after that.

## Verification

- Full suite green under pyannote.audio 4.0.4: **72 passed, 2 skipped**.
- End-to-end diarization confirmed on Apple Silicon (MPS).

## Follow-up

Broaden the eval subset beyond 3 meetings for a tighter DER estimate (tracked as the open item in #2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
