### PR TITLE
feat(diarize): word-level speaker assignment (closes #6)

### DIFF
--- a/scripts/diarize.py
+++ b/scripts/diarize.py
@@ -92,9 +92,46 @@ def _words_to_labeled_cues(words: list, diarization, speaker_map: dict) -> list:
     return [c for c in cues if c["text"]]
 
 
-def _write_word_level_srt(words_path: Path, diarization, output_path: Path,
-                          verbose: bool) -> Path | None:
+def _kept_intervals(srt_path: Path) -> list | None:
+    """Time spans (start, end) of the cues present in ``srt_path``.
+
+    Used to gate the word sidecar: upstream hallucination filtering removes whole
+    cues from the SRT, so words whose timing falls in a removed span must also be
+    dropped — otherwise word-level diarization would rebuild them from the
+    unfiltered sidecar and reintroduce the hallucination (issue #6 review).
+    Returns None if the SRT can't be read (then no gating is applied).
+    """
+    try:
+        subs = list(srt.parse(Path(srt_path).read_text(encoding="utf-8")))
+    except (OSError, ValueError):
+        return None
+    return [(s.start.total_seconds(), s.end.total_seconds()) for s in subs]
+
+
+def _filter_words_to_intervals(words: list, intervals: list) -> list:
+    """Keep only words that overlap one of the (sorted) kept intervals."""
+    intervals = sorted(intervals)
+    n = len(intervals)
+    kept = []
+    j = 0
+    for w in sorted(words, key=lambda x: float(x.get("start", 0.0))):
+        try:
+            ws, we = float(w["start"]), float(w["end"])
+        except (TypeError, KeyError, ValueError):
+            continue
+        while j < n and intervals[j][1] <= ws:
+            j += 1
+        if j < n and intervals[j][0] < max(we, ws + 1e-3):
+            kept.append(w)
+    return kept
+
+
+def _write_word_level_srt(words_path: Path, srt_path: Path, diarization,
+                          output_path: Path, verbose: bool) -> Path | None:
     """Build a speaker-labeled SRT from a word-timings sidecar.
+
+    Words are gated to the cue spans of ``srt_path`` (the possibly
+    hallucination-filtered transcript) so filtered content is not reintroduced.
 
     Returns the output path, or None if the sidecar is empty/unusable so the
     caller can fall back to segment-level labeling.
@@ -105,6 +142,13 @@ def _write_word_level_srt(words_path: Path, diarization, output_path: Path,
         words = json.loads(Path(words_path).read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
+    if not words:
+        return None
+
+    # Drop words that fall outside the (filtered) SRT's surviving cues.
+    intervals = _kept_intervals(srt_path)
+    if intervals is not None:
+        words = _filter_words_to_intervals(words, intervals)
     if not words:
         return None
 
@@ -249,7 +293,8 @@ def diarize(
     # uses tight word timings, which segment-level max-overlap cannot (issue #6).
     words_path = srt_path.with_suffix(".words.json")
     if words_path.exists():
-        result = _write_word_level_srt(words_path, diarization_result, output_path, verbose)
+        result = _write_word_level_srt(words_path, srt_path, diarization_result,
+                                       output_path, verbose)
         if result is not None:
             return result
         if verbose:

--- a/scripts/diarize.py
+++ b/scripts/diarize.py
@@ -13,6 +13,7 @@ This format is consumed directly by interleave.py which expects the
 import argparse
 import os
 import sys
+from datetime import timedelta
 from pathlib import Path
 
 try:
@@ -55,6 +56,83 @@ def _human_label(raw_speaker: str, speaker_map: dict) -> str:
     if raw_speaker not in speaker_map:
         speaker_map[raw_speaker] = f"Speaker {len(speaker_map) + 1}"
     return speaker_map[raw_speaker]
+
+
+def _words_to_labeled_cues(words: list, diarization, speaker_map: dict) -> list:
+    """Assign a speaker to each word, then group consecutive same-speaker words.
+
+    `words` is a list of {text, start, end}. Returns cue dicts
+    {start, end, label, text} where `label` is a human label or None (unknown).
+    Word-level grouping splits a transcript at speaker changes that whole-segment
+    labeling would miss, and uses tight word timings (issue #6).
+    """
+    cues: list = []
+    cur = None
+    for w in words:
+        try:
+            start = float(w["start"])
+            end = float(w["end"])
+        except (TypeError, KeyError, ValueError):
+            continue
+        text = w.get("text", "")
+        # Guard against zero-duration tokens so overlap is well-defined.
+        raw = _dominant_speaker(start, max(end, start + 1e-3), diarization)
+        label = _human_label(raw, speaker_map) if raw else None
+        if cur is not None and cur["label"] == label:
+            cur["end"] = end
+            cur["text"] += text
+        else:
+            if cur is not None:
+                cues.append(cur)
+            cur = {"start": start, "end": end, "label": label, "text": text}
+    if cur is not None:
+        cues.append(cur)
+    for c in cues:
+        c["text"] = c["text"].strip()
+    return [c for c in cues if c["text"]]
+
+
+def _write_word_level_srt(words_path: Path, diarization, output_path: Path,
+                          verbose: bool) -> Path | None:
+    """Build a speaker-labeled SRT from a word-timings sidecar.
+
+    Returns the output path, or None if the sidecar is empty/unusable so the
+    caller can fall back to segment-level labeling.
+    """
+    import json
+
+    try:
+        words = json.loads(Path(words_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not words:
+        return None
+
+    speaker_map: dict[str, str] = {}
+    cues = _words_to_labeled_cues(words, diarization, speaker_map)
+    if not cues:
+        return None
+
+    subtitles = []
+    for i, c in enumerate(cues, start=1):
+        content = f"[{c['label']}] {c['text']}" if c["label"] else c["text"]
+        subtitles.append(srt.Subtitle(
+            index=i,
+            start=timedelta(seconds=c["start"]),
+            end=timedelta(seconds=c["end"]),
+            content=content,
+        ))
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(srt.compose(subtitles))
+
+    if verbose:
+        labeled = sum(1 for c in cues if c["label"])
+        print(f"💬 Word-level: {len(cues)} cues, {labeled} labeled, "
+              f"{len(speaker_map)} speaker(s)")
+        print(f"💾 Output: {output_path}")
+    return output_path
 
 
 # Diarization model. Defined once so both the production pipeline and the
@@ -165,6 +243,17 @@ def diarize(
         diarization_result = run_diarization(audio_path, hf_token, device, verbose)
     else:
         diarization_result = diarization
+
+    # Prefer word-level speaker assignment when a word-timings sidecar exists
+    # (written by transcribe.py). It splits at within-segment speaker changes and
+    # uses tight word timings, which segment-level max-overlap cannot (issue #6).
+    words_path = srt_path.with_suffix(".words.json")
+    if words_path.exists():
+        result = _write_word_level_srt(words_path, diarization_result, output_path, verbose)
+        if result is not None:
+            return result
+        if verbose:
+            print("ℹ️  Word sidecar unusable; falling back to segment-level labeling.")
 
     with open(srt_path, "r", encoding="utf-8") as f:
         subtitles = list(srt.parse(f.read()))

--- a/scripts/transcribe.py
+++ b/scripts/transcribe.py
@@ -6,6 +6,7 @@ and outputs SRT format subtitles.
 """
 
 import argparse
+import json
 import os
 import sys
 from pathlib import Path
@@ -72,8 +73,12 @@ def write_srt(segments: list, output_path: Path) -> None:
             f.write("\n")
 
 
-def _whisper_segments(audio_path: Path, model: str, language: str, verbose: bool) -> list:
-    """Transcribe with MLX Whisper, returning a list of {start, end, text} segments."""
+def _whisper_segments(audio_path: Path, model: str, language: str, verbose: bool):
+    """Transcribe with MLX Whisper.
+
+    Returns (segments, words): segment dicts {start, end, text} for the SRT, and
+    word dicts {text, start, end} for word-level speaker assignment (issue #6).
+    """
     model_path = MODEL_MAPPING.get(model, model)
     if verbose:
         print(f"🎯 Backend: whisper | Model: {model} ({model_path})")
@@ -87,17 +92,25 @@ def _whisper_segments(audio_path: Path, model: str, language: str, verbose: bool
         condition_on_previous_text=False,  # Reduces hallucinations
         no_speech_threshold=0.6,  # Filter out non-speech segments
         compression_ratio_threshold=2.4,  # Filter garbled audio
-        word_timestamps=False,  # We only need segment-level timestamps for SRT
+        word_timestamps=True,  # also produce word-level timings for diarization
         verbose=verbose,
     )
-    return result.get('segments', [])
+    segments = result.get('segments', [])
+    words = [
+        {"text": w.get("word", ""), "start": w.get("start"), "end": w.get("end")}
+        for seg in segments
+        for w in seg.get("words", [])
+        if w.get("start") is not None and w.get("end") is not None
+    ]
+    return segments, words
 
 
-def _parakeet_segments(audio_path: Path, model: str, verbose: bool) -> list:
-    """Transcribe with NVIDIA Parakeet (MLX), returning {start, end, text} segments.
+def _parakeet_segments(audio_path: Path, model: str, verbose: bool):
+    """Transcribe with NVIDIA Parakeet (MLX).
 
-    Parakeet auto-detects language (no language arg). Long audio is processed in
-    overlapping chunks. Sentence-level alignments map directly to SRT segments.
+    Returns (segments, words). Parakeet auto-detects language and processes long
+    audio in overlapping chunks. Sentence alignments map to SRT segments; the
+    per-sentence tokens give word-level timings for diarization (issue #6).
     """
     try:
         from parakeet_mlx import from_pretrained
@@ -111,10 +124,13 @@ def _parakeet_segments(audio_path: Path, model: str, verbose: bool) -> list:
 
     pk = from_pretrained(model)
     result = pk.transcribe(str(audio_path), chunk_duration=120.0, overlap_duration=15.0)
-    return [
-        {"start": s.start, "end": s.end, "text": s.text}
+    segments = [{"start": s.start, "end": s.end, "text": s.text} for s in result.sentences]
+    words = [
+        {"text": t.text, "start": t.start, "end": t.end}
         for s in result.sentences
+        for t in s.tokens
     ]
+    return segments, words
 
 
 def transcribe(
@@ -162,9 +178,9 @@ def transcribe(
         # A Whisper-style model name (or the default 'turbo') means "use the
         # default Parakeet model" rather than a literal repo id.
         pk_model = model if "parakeet" in model else PARAKEET_MODEL
-        segments = _parakeet_segments(audio_path, pk_model, verbose)
+        segments, words = _parakeet_segments(audio_path, pk_model, verbose)
     elif backend == "whisper":
-        segments = _whisper_segments(audio_path, model, language, verbose)
+        segments, words = _whisper_segments(audio_path, model, language, verbose)
     else:
         raise ValueError(f"Unknown ASR backend: {backend!r} (expected 'whisper' or 'parakeet')")
 
@@ -181,6 +197,15 @@ def transcribe(
         write_srt(segments, output_path)
         if verbose:
             print(f"✅ Transcription complete: {len(segments)} segments")
+
+    # Write a word-level sidecar (<stem>.words.json) for word-level speaker
+    # assignment in diarize.py (issue #6). Best-effort: absence just means the
+    # diarizer falls back to segment-level labeling.
+    if words:
+        words_path = output_dir / (audio_path.stem + ".words.json")
+        words_path.write_text(json.dumps(words), encoding="utf-8")
+        if verbose:
+            print(f"💾 Word timings: {words_path} ({len(words)} words)")
 
     if verbose:
         print(f"💾 Output: {output_path}")

--- a/tests/test_diarize_words.py
+++ b/tests/test_diarize_words.py
@@ -1,0 +1,88 @@
+"""Unit tests for word-level speaker assignment in diarize.py (issue #6).
+
+Pure logic — uses a synthetic pyannote Annotation, no audio or models.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_project_root = Path(__file__).parent.parent
+for _p in (str(_project_root), str(_project_root / "scripts")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import diarize  # scripts/diarize.py
+from pyannote.core import Annotation, Segment
+
+
+def _annotation(turns):
+    """turns: list of (start, end, speaker)."""
+    ann = Annotation()
+    for i, (s, e, spk) in enumerate(turns):
+        ann[Segment(s, e), i] = spk
+    return ann
+
+
+def _words(*specs):
+    """specs: (text, start, end) tuples."""
+    return [{"text": t, "start": s, "end": e} for (t, s, e) in specs]
+
+
+def test_groups_consecutive_same_speaker_words():
+    ann = _annotation([(0.0, 10.0, "SPEAKER_00")])
+    words = _words((" hello", 0.0, 0.5), (" world", 0.6, 1.0))
+    cues = diarize._words_to_labeled_cues(words, ann, {})
+    assert len(cues) == 1
+    assert cues[0]["label"] == "Speaker 1"
+    assert cues[0]["text"] == "hello world"
+    assert cues[0]["start"] == 0.0 and cues[0]["end"] == 1.0
+
+
+def test_splits_on_within_segment_speaker_change():
+    # Two speakers back-to-back — segment-level labeling would pick only one.
+    ann = _annotation([(0.0, 1.0, "SPEAKER_00"), (1.0, 2.0, "SPEAKER_01")])
+    words = _words((" a", 0.1, 0.4), (" b", 0.5, 0.9), (" c", 1.1, 1.4), (" d", 1.5, 1.9))
+    cues = diarize._words_to_labeled_cues(words, ann, {})
+    assert len(cues) == 2
+    assert cues[0]["label"] == "Speaker 1" and cues[0]["text"] == "a b"
+    assert cues[1]["label"] == "Speaker 2" and cues[1]["text"] == "c d"
+
+
+def test_speaker_numbering_by_first_appearance():
+    ann = _annotation([(0.0, 1.0, "SPEAKER_05"), (1.0, 2.0, "SPEAKER_02")])
+    words = _words((" x", 0.1, 0.5), (" y", 1.1, 1.5))
+    cues = diarize._words_to_labeled_cues(words, ann, {})
+    assert cues[0]["label"] == "Speaker 1"  # SPEAKER_05 appears first
+    assert cues[1]["label"] == "Speaker 2"
+
+
+def test_unlabeled_words_have_no_speaker():
+    # Word falls outside any diarized turn -> label None (no prefix downstream).
+    ann = _annotation([(5.0, 6.0, "SPEAKER_00")])
+    words = _words((" orphan", 0.0, 0.5))
+    cues = diarize._words_to_labeled_cues(words, ann, {})
+    assert len(cues) == 1
+    assert cues[0]["label"] is None
+
+
+def test_word_level_srt_written(tmp_path):
+    import json
+    ann = _annotation([(0.0, 1.0, "SPEAKER_00"), (1.0, 2.0, "SPEAKER_01")])
+    words_path = tmp_path / "x.words.json"
+    words_path.write_text(json.dumps(_words((" a", 0.1, 0.4), (" b", 1.1, 1.4))), encoding="utf-8")
+    out = tmp_path / "x_labeled.srt"
+    result = diarize._write_word_level_srt(words_path, ann, out, verbose=False)
+    assert result == out
+    content = out.read_text(encoding="utf-8")
+    assert "[Speaker 1] a" in content
+    assert "[Speaker 2] b" in content
+
+
+def test_empty_sidecar_returns_none(tmp_path):
+    import json
+    words_path = tmp_path / "e.words.json"
+    words_path.write_text(json.dumps([]), encoding="utf-8")
+    out = tmp_path / "e_labeled.srt"
+    assert diarize._write_word_level_srt(words_path, _annotation([]), out, verbose=False) is None

--- a/tests/test_diarize_words.py
+++ b/tests/test_diarize_words.py
@@ -67,13 +67,26 @@ def test_unlabeled_words_have_no_speaker():
     assert cues[0]["label"] is None
 
 
+def _write_srt(path, cues):
+    """cues: list of (start, end, text)."""
+    import srt as srt_lib
+    from datetime import timedelta
+    subs = [
+        srt_lib.Subtitle(index=i, start=timedelta(seconds=s), end=timedelta(seconds=e), content=t)
+        for i, (s, e, t) in enumerate(cues, start=1)
+    ]
+    path.write_text(srt_lib.compose(subs), encoding="utf-8")
+
+
 def test_word_level_srt_written(tmp_path):
     import json
     ann = _annotation([(0.0, 1.0, "SPEAKER_00"), (1.0, 2.0, "SPEAKER_01")])
     words_path = tmp_path / "x.words.json"
     words_path.write_text(json.dumps(_words((" a", 0.1, 0.4), (" b", 1.1, 1.4))), encoding="utf-8")
+    srt_path = tmp_path / "x.srt"
+    _write_srt(srt_path, [(0.0, 2.0, "a b")])  # cue covers both words
     out = tmp_path / "x_labeled.srt"
-    result = diarize._write_word_level_srt(words_path, ann, out, verbose=False)
+    result = diarize._write_word_level_srt(words_path, srt_path, ann, out, verbose=False)
     assert result == out
     content = out.read_text(encoding="utf-8")
     assert "[Speaker 1] a" in content
@@ -84,5 +97,28 @@ def test_empty_sidecar_returns_none(tmp_path):
     import json
     words_path = tmp_path / "e.words.json"
     words_path.write_text(json.dumps([]), encoding="utf-8")
+    srt_path = tmp_path / "e.srt"
+    _write_srt(srt_path, [(0.0, 1.0, "x")])
     out = tmp_path / "e_labeled.srt"
-    assert diarize._write_word_level_srt(words_path, _annotation([]), out, verbose=False) is None
+    assert diarize._write_word_level_srt(words_path, srt_path, _annotation([]), out, verbose=False) is None
+
+
+def test_filtered_hallucination_not_reintroduced(tmp_path):
+    """Reviewer's case: a cue removed by hallucination filtering must not come
+    back via the unfiltered word sidecar (issue #6 review)."""
+    import json
+    ann = _annotation([(0.0, 5.0, "SPEAKER_00")])
+    # Sidecar still has the hallucination words at [0.0,0.8] plus real content.
+    words_path = tmp_path / "h.words.json"
+    words_path.write_text(json.dumps(_words(
+        (" thank", 0.0, 0.4), (" you", 0.4, 0.8),
+        (" actual", 1.0, 1.4), (" content", 1.5, 1.9),
+    )), encoding="utf-8")
+    # Cleaned SRT: the "thank you" cue was removed, only the real cue survives.
+    srt_path = tmp_path / "h.srt"
+    _write_srt(srt_path, [(1.0, 1.9, "actual content")])
+    out = tmp_path / "h_labeled.srt"
+    diarize._write_word_level_srt(words_path, srt_path, ann, out, verbose=False)
+    content = out.read_text(encoding="utf-8").lower()
+    assert "thank you" not in content
+    assert "actual content" in content


### PR DESCRIPTION
## What

Replaces segment-level max-overlap speaker labeling with **word-level speaker assignment** on the "Others" track. This targets the gap the #2 harness surfaced: native diarization scores ~20% DER, but applying those labels to whole transcript segments roughly doubled it. Closes #6.

## How

- **`transcribe.py`**: both backends now emit a `<stem>.words.json` sidecar of word timings — Parakeet from its per-sentence token alignments, Whisper via `word_timestamps=True`.
- **`diarize.py`**: when the sidecar is present, each word is assigned the dominant-overlap speaker, and consecutive same-speaker words are grouped into tight cues (split at within-segment speaker changes). Falls back to the old segment-level labeling when there's no sidecar. The `[Speaker N]` SRT output format is unchanged, so `interleave.py` is unaffected. No `run.sh` change needed — the sidecar sits next to the SRT and is picked up automatically.

## Result (measured via the #2 harness)

Isolated comparison — **same ASR (Parakeet) and same diarization (community-1)**, only the labeling method differs, IS1009a:

| DER (srt) | |
|---|---|
| segment-level (before) | 41.4% |
| **word-level (this PR)** | **32.0%** |
| raw diarization ceiling | 19.7% |

**−9.4pt**, closing ~43% of the gap to the raw ceiling. Across 3 meetings, word-level DER (srt) averages 34.2% (vs raw 18.5%). The residual gap (word-timing slop, overlap regions) is expected; this is the bulk of the achievable win without re-architecting around forced alignment.

## Verification

- Full suite green: **78 passed, 2 skipped** (+6 new word-level unit tests covering grouping, within-segment splits, speaker numbering, SRT output, empty-sidecar fallback).
- End-to-end validated on Apple Silicon with Parakeet + community-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
