### PR TITLE
fix(run): delete word-timing sidecars so temp dirs are cleaned up

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -452,7 +452,11 @@ for entry in entries:
                     echo "Final transcript verified successfully."
                     safe_delete "$TARGET_DIR/${FINAL_BASENAME}_me.srt" "transcript file (me)"
                     safe_delete "$TARGET_DIR/${FINAL_BASENAME}_others.srt" "transcript file (others)"
-                    
+                    # Word-timing sidecars (written by transcribe.py, consumed by diarize.py)
+                    # are no longer needed once diarization/interleaving are done.
+                    safe_delete "$TARGET_DIR/${FINAL_BASENAME}_me.words.json" "word sidecar (me)"
+                    safe_delete "$TARGET_DIR/${FINAL_BASENAME}_others.words.json" "word sidecar (others)"
+
                     # Clean up the temporary directory if it's empty (no raw recording kept)
                     if [ "${KEEP_RAW_RECORDING}" != "true" ]; then
                         # Check if directory is empty


### PR DESCRIPTION
## Problem

Since the word-level diarization changes (#10 / issue #6), a temporary directory was left behind for every processed meeting.

- `transcribe.py` writes a `<stem>.words.json` word-timing sidecar per track (`_me`, `_others`).
- `diarize.py` consumes that sidecar for word-level speaker assignment.
- Nothing ever deleted the sidecars. The empty-directory check before `rmdir` in `run.sh` (`[ -z "$(ls -A "$TARGET_DIR")" ]`) then always failed, so the temp dir was never removed.

## Fix

Delete the `_me`/`_others` `.words.json` sidecars alongside the existing SRT cleanup, after the final transcript is verified. By that point diarization has already consumed them, so they're safe to remove. `safe_delete` no-ops cleanly when a sidecar isn't present.

## Testing

Verified the leftover dirs from today's meetings contained only the two orphaned sidecars each (with all final transcripts present), then removed them manually. With this change, the empty-directory check will now succeed and `rmdir` will fire as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)